### PR TITLE
fix: Use ClaimTypes.Name instead of a custom claim #44

### DIFF
--- a/Commands/Constants/CustomClaims.cs
+++ b/Commands/Constants/CustomClaims.cs
@@ -1,6 +1,0 @@
-namespace Commands.Constants;
-
-public static class CustomClaims
-{
-    public static readonly string Name = "name";
-}

--- a/Commands/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Commands/Extensions/ClaimsPrincipalExtensions.cs
@@ -8,6 +8,6 @@ public static class ClaimsPrincipalExtensions
 {
     public static string? GetName(this ClaimsPrincipal user)
     {
-        return user.FindFirstValue(CustomClaims.Name);
+        return user.FindFirstValue(ClaimTypes.Name);
     }
 }

--- a/Commands/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Commands/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,7 +1,5 @@
 using System.Security.Claims;
 
-using Commands.Constants;
-
 namespace Commands.Extensions;
 
 public static class ClaimsPrincipalExtensions


### PR DESCRIPTION
Issue was related to a claim that was not using a correct name