### PR TITLE
Add membership active/inactive state and filtering capabilities to overview

### DIFF
--- a/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
@@ -33,7 +33,7 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
 
         if(!request.ShowActive)
         {
-            memberQueryable = memberQueryable.Where(m => m.MembershipExpiryDate == null || m.MembershipExpiryDate!.Value <= DateTimeOffset.Now);
+            memberQueryable = memberQueryable.Where(m => m.MembershipExpiryDate != null && m.MembershipExpiryDate.Value <= DateTimeOffset.Now);
         }
 
         if(!request.ShowInactive)

--- a/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
@@ -66,6 +66,8 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
                     .ThenBy(m => m.LastName),
                 MemberSummaryOrderOption.PhoneNumber => memberQueryable
                     .OrderBy(m => m.PhoneNumber),
+                MemberSummaryOrderOption.IsActive => memberQueryable
+                    .OrderBy(m => m.IsActive()),
                 _ => memberQueryable
                     .OrderBy(m => m.FirstName)
                     .ThenBy(m => m.LastName)
@@ -86,6 +88,8 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
                     .ThenBy(m => m.LastName),
                 MemberSummaryOrderOption.PhoneNumber => memberQueryable
                     .OrderByDescending(m => m.PhoneNumber),
+                MemberSummaryOrderOption.IsActive => memberQueryable
+                    .OrderByDescending(m => m.IsActive()),
                 _ => memberQueryable
                     .OrderByDescending(m => m.FirstName)
                     .ThenBy(m => m.LastName)

--- a/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
@@ -29,7 +29,17 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
         var context = _contextFactory.CreateDbContext();
         var memberQueryable = context.Members
             .AsNoTracking()
-            .Where(GetFilterCriteria(request.SearchString));
+            .Where(GetTextFilterCriteria(request.SearchString));
+
+        if(!request.ShowActive)
+        {
+            memberQueryable = memberQueryable.Where(m => m.MembershipExpiryDate == null || m.MembershipExpiryDate!.Value <= DateTimeOffset.Now);
+        }
+
+        if(!request.ShowInactive)
+        {
+            memberQueryable = memberQueryable.Where(m => m.MembershipExpiryDate == null || m.MembershipExpiryDate!.Value > DateTimeOffset.Now);
+        }
 
         var total = await memberQueryable.CountAsync(cancellationToken);
 
@@ -52,6 +62,7 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
     private static IQueryable<Member> GetOrderedQueryable(SearchMembersQuery request, IQueryable<Member> memberQueryable)
     {
         if (request.SortDirection == SortDirection.Ascending)
+        {
             memberQueryable = request.OrderBy switch
             {
                 MemberSummaryOrderOption.Address => memberQueryable
@@ -72,8 +83,10 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
                     .OrderBy(m => m.FirstName)
                     .ThenBy(m => m.LastName)
             };
+        }
 
         if (request.SortDirection == SortDirection.Descending)
+        {
             memberQueryable = request.OrderBy switch
             {
                 MemberSummaryOrderOption.Address => memberQueryable
@@ -94,10 +107,12 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
                     .OrderByDescending(m => m.FirstName)
                     .ThenBy(m => m.LastName)
             };
+        }
+
         return memberQueryable;
     }
 
-    private static Expression<Func<Member, bool>> GetFilterCriteria(string searchString)
+    private static Expression<Func<Member, bool>> GetTextFilterCriteria(string searchString)
     {
         var lowerCaseSearchString = searchString.ToLower();
         return m => m.Address.City.ToLower().Contains(lowerCaseSearchString) ||
@@ -109,6 +124,5 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
                    m.FirstName.ToLower().Contains(lowerCaseSearchString) ||
                    m.LastName.ToLower().Contains(lowerCaseSearchString) ||
                    (m.PhoneNumber != null && m.PhoneNumber.ToLower().Contains(lowerCaseSearchString));
-
     }
 }

--- a/Queries/Members/Handlers/SearchMembers/SearchMembersQuery.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersQuery.cs
@@ -18,5 +18,6 @@ public enum MemberSummaryOrderOption
     Name,
     Address,
     Email,
-    PhoneNumber
+    PhoneNumber,
+    IsActive
 }

--- a/Queries/Members/Handlers/SearchMembers/SearchMembersQuery.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersQuery.cs
@@ -7,6 +7,8 @@ namespace Queries.Members.Handlers.SearchMembers;
 
 public record SearchMembersQuery(
     string SearchString,
+    bool ShowActive,
+    bool ShowInactive,
     int PageIndex,
     int PageSize,
     MemberSummaryOrderOption OrderBy,

--- a/Queries/Members/ViewModels/MemberSummary.cs
+++ b/Queries/Members/ViewModels/MemberSummary.cs
@@ -6,5 +6,6 @@ public record MemberSummary(
     string Address,
     string Email,
     string PhoneNumber,
-    bool IsActive
+    bool IsActive,
+    DateTimeOffset MembershipExpiryDate
 );

--- a/Web/Pages/Members/Members.razor
+++ b/Web/Pages/Members/Members.razor
@@ -12,7 +12,7 @@
 <MudTable Class="mt-10 mw-13"
           Dense="true"
           Hover="true"
-          @ref="table"
+          @ref="_table"
           ServerData="@(new Func<TableState, Task<TableData<MemberSummary>>>(ServerReload))"
           Loading="@loading">
     <ToolBarContent>
@@ -20,12 +20,14 @@
         <MudSpacer />
         <MudTextField Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search"
+                      @bind-Value="@SearchString"
                       Class="mt-0"
                       IconSize="Size.Medium"
                       Placeholder="Search"
-                      T="string"
-                      ValueChanged="@(s => OnSearch(s))">
+                      T="string">
         </MudTextField>
+        <MudSwitch @bind-Checked="@ShowActive" Label="Active" Color="Color.Success" T="bool" />
+        <MudSwitch @bind-Checked="@ShowInactive" Label="Inactive" Color="Color.Error" T="bool" />
         <MudSpacer />
         <MudButton Class="ma-2"
                    Color="Color.Primary"
@@ -113,8 +115,35 @@
 </MudTable>
 
 @code {
-    private MudTable<MemberSummary>? table;
-    private string searchString = "";
+    private MudTable<MemberSummary>? _table;
+    private string _searchString = "";
+    public string SearchString
+    {
+        get => _searchString;
+        set
+        {
+            _searchString = value;
+            _table?.ReloadServerData();
+        }
+    }
+    private bool _showActive = true;
+    public bool ShowActive {
+        get => _showActive;
+        set
+        {
+            _showActive = value;
+            _table?.ReloadServerData();
+        }
+    }
+
+    private bool _showInactive = true;
+    public bool ShowInactive {
+        get => _showInactive;
+        set{
+            _showInactive = value;
+            _table?.ReloadServerData();
+        }
+    }
 
     // TODO: Keeping this local variable shouldn't be necessary 
     // because the MudTable ServerData feature should take care of displaying the loading bar appropriately
@@ -135,7 +164,7 @@
             _ => MemberSummaryOrderOption.Name
         };
         var sortDirection = (Queries.Enums.SortDirection)(int)state.SortDirection;
-        var query = new SearchMembersQuery(searchString, state.Page, state.PageSize, orderBy, sortDirection);
+        var query = new SearchMembersQuery(_searchString,ShowActive, _showInactive, state.Page, state.PageSize, orderBy, sortDirection);
         var data = await _mediator.Send(query);
 
         loading = false;
@@ -144,12 +173,6 @@
             TotalItems = data.Total,
             Items = data.Items
         };
-    }
-
-    private void OnSearch(string text)
-    {
-        searchString = text;
-        table?.ReloadServerData();
     }
 
     private async Task OpenDeleteMemberDialog(MemberSummary member)
@@ -165,7 +188,7 @@
         {
             Snackbar.Clear();
             Snackbar.Add($"Removed {member.Name} as a member");
-            table?.ReloadServerData();
+            _table?.ReloadServerData();
         }
     }
     private string GetActiveIcon(MemberSummary member) => member.IsActive

--- a/Web/Pages/Members/Members.razor
+++ b/Web/Pages/Members/Members.razor
@@ -63,6 +63,12 @@
             </MudTableSortLabel>
         </MudTh>
         <MudTh>
+            <MudTableSortLabel SortLabel="isActive"
+                               T="MemberSummary">
+                Active
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
             Action
         </MudTh>
     </HeaderContent>
@@ -71,6 +77,9 @@
         <MudTd DataLabel="Address">@context.Address</MudTd>
         <MudTd DataLabel="Email">@context.Email</MudTd>
         <MudTd DataLabel="PhoneNumber">@context.PhoneNumber</MudTd>
+        <MudTd DataLabel="IsActive">
+            <MudIcon Icon="@GetActiveIcon(context)" Title="@GetExpiryDate(context)" Color="@GetActiveIconColor(context)" />
+        </MudTd>
         <MudTd>
             <MudGrid >
                 <MudItem xs="6">
@@ -122,6 +131,7 @@
             "address" => MemberSummaryOrderOption.Address,
             "email" => MemberSummaryOrderOption.Email,
             "phoneNumber" => MemberSummaryOrderOption.PhoneNumber,
+            "isActive"=> MemberSummaryOrderOption.IsActive,
             _ => MemberSummaryOrderOption.Name
         };
         var sortDirection = (Queries.Enums.SortDirection)(int)state.SortDirection;
@@ -158,5 +168,13 @@
             table?.ReloadServerData();
         }
     }
+    private string GetActiveIcon(MemberSummary member) => member.IsActive
+        ? Icons.Filled.CheckBox
+        : Icons.Filled.CheckBoxOutlineBlank;
+        
+    private Color GetActiveIconColor(MemberSummary member) => member.IsActive
+        ? Color.Success
+        : Color.Error;
 
+    private string GetExpiryDate(MemberSummary member) => member.MembershipExpiryDate.Date.ToString("dd/MM/yyyy");
 }


### PR DESCRIPTION
This PR adds a checkbox to the member overview list to visualize which members have an active membership vs inactive membership.
Also it adds filtering capabilities to the list for membership state.

![image](https://user-images.githubusercontent.com/3620147/191075131-666f8f3c-751d-43a6-a894-0eda5b798e7e.png)
![image](https://user-images.githubusercontent.com/3620147/191075259-724908ec-ebb4-4b10-b441-006c9d8cc9a0.png)

I'm not happy about having to rewrite the expressions for determining whether a member is active or not, we should be using the `Domain.Member.IsActive()` method for this, but EFCore is unable to translate that method into an expression :(