### PR TITLE
fix: NavigateTo in OnAfterRender

### DIFF
--- a/Web/Shared/RedirectTo.razor
+++ b/Web/Shared/RedirectTo.razor
@@ -3,9 +3,10 @@
 @code {
     [Parameter]
     public string Uri { get; set; } = string.Empty;
-    
-    protected override void OnInitialized()
+
+    protected override void OnAfterRender(bool firstRender)
     {
+        base.OnAfterRender(firstRender);
         Navigation.NavigateTo(Uri, true);
     }
 }


### PR DESCRIPTION
There seems to be a bug with OnInitialized and the NavigationManager: https://github.com/dotnet/aspnetcore/issues/13582