### PR TITLE
Feature/#54

### DIFF
--- a/Commands/Handlers/Member/EditMember/EditMemberHandler.cs
+++ b/Commands/Handlers/Member/EditMember/EditMemberHandler.cs
@@ -5,8 +5,7 @@ using Domain.Interfaces;
 
 namespace Commands.Handlers.Member.EditMember;
 
-public class
-    EditMemberHandler : IRequestHandler<EditMemberCommand>
+public class EditMemberHandler : IRequestHandler<EditMemberCommand>
 {
     private readonly IMemberRepository _memberRepository;
     private readonly IUserAccessor _userAccessor;

--- a/Commands/Handlers/Member/EditMember/EditMemberHandler.cs
+++ b/Commands/Handlers/Member/EditMember/EditMemberHandler.cs
@@ -9,13 +9,11 @@ public class
     EditMemberHandler : IRequestHandler<EditMemberCommand>
 {
     private readonly IMemberRepository _memberRepository;
-    private readonly IMapper _mapper;
     private readonly IUserAccessor _userAccessor;
 
-    public EditMemberHandler(IMemberRepository memberRepository, IMapper mapper, IUserAccessor userAccessor)
+    public EditMemberHandler(IMemberRepository memberRepository, IUserAccessor userAccessor)
     {
         _memberRepository = memberRepository;
-        _mapper = mapper;
         _userAccessor = userAccessor;
     }
 

--- a/Commands/Handlers/Member/ExtendMembership/ExtendMembershipCommand.cs
+++ b/Commands/Handlers/Member/ExtendMembership/ExtendMembershipCommand.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using FluentValidation;
+﻿using FluentValidation;
 
 namespace Commands.Handlers.Member.ExtendMembership;
 
@@ -14,6 +8,8 @@ public class ExtendMembershipCommandValidator : AbstractValidator<ExtendMembersh
 {
     public ExtendMembershipCommandValidator()
     {
+        RuleFor(x => x.Id)
+            .NotEmpty();
         RuleFor(x => x.NewMembershipExpirationDate)
             .NotEmpty()
             .GreaterThan(DateTime.Now);

--- a/Commands/Handlers/Member/ExtendMembership/ExtendMembershipCommand.cs
+++ b/Commands/Handlers/Member/ExtendMembership/ExtendMembershipCommand.cs
@@ -4,11 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using Commands.Extensions;
-using Commands.Services;
-
-using Domain.Interfaces;
-
 using FluentValidation;
 
 namespace Commands.Handlers.Member.ExtendMembership;
@@ -22,33 +17,5 @@ public class ExtendMembershipCommandValidator : AbstractValidator<ExtendMembersh
         RuleFor(x => x.NewMembershipExpirationDate)
             .NotEmpty()
             .GreaterThan(DateTime.Now);
-    }
-}
-
-public class ExtendMembershipHandler : IRequestHandler<ExtendMembershipCommand>
-{
-    private readonly IMemberRepository _repository;
-    private readonly IUserAccessor _userAccessor;
-
-    public ExtendMembershipHandler(IMemberRepository repository, IUserAccessor userAccessor)
-    {
-        _repository = repository;
-        _userAccessor = userAccessor;
-    }
-
-    public async Task<Unit> Handle(ExtendMembershipCommand request, CancellationToken cancellationToken)
-    {
-        var member = await _repository.GetById(request.Id);
-
-        if (member == null)
-            throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
-
-        var performingUser = _userAccessor.User.GetName()!;
-
-        member.ChangeMembershipExpiryDate(request.NewMembershipExpirationDate, performingUser);
-
-        await _repository.Save(cancellationToken);
-
-        return Unit.Value;
     }
 }

--- a/Commands/Handlers/Member/ExtendMembership/ExtendMembershipCommand.cs
+++ b/Commands/Handlers/Member/ExtendMembership/ExtendMembershipCommand.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Commands.Extensions;
+using Commands.Services;
+
+using Domain.Interfaces;
+
+using FluentValidation;
+
+namespace Commands.Handlers.Member.ExtendMembership;
+
+public record ExtendMembershipCommand(Guid Id, DateTime NewMembershipExpirationDate) : IRequest;
+
+public class ExtendMembershipCommandValidator : AbstractValidator<ExtendMembershipCommand>
+{
+    public ExtendMembershipCommandValidator()
+    {
+        RuleFor(x => x.NewMembershipExpirationDate)
+            .NotEmpty()
+            .GreaterThan(DateTime.Now);
+    }
+}
+
+public class ExtendMembershipHandler : IRequestHandler<ExtendMembershipCommand>
+{
+    private readonly IMemberRepository _repository;
+    private readonly IUserAccessor _userAccessor;
+
+    public ExtendMembershipHandler(IMemberRepository repository, IUserAccessor userAccessor)
+    {
+        _repository = repository;
+        _userAccessor = userAccessor;
+    }
+
+    public async Task<Unit> Handle(ExtendMembershipCommand request, CancellationToken cancellationToken)
+    {
+        var member = await _repository.GetById(request.Id);
+
+        if (member == null)
+            throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
+
+        var performingUser = _userAccessor.User.GetName()!;
+
+        member.ChangeMembershipExpiryDate(request.NewMembershipExpirationDate, performingUser);
+
+        await _repository.Save(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/Commands/Handlers/Member/ExtendMembership/ExtendMembershipHandler.cs
+++ b/Commands/Handlers/Member/ExtendMembership/ExtendMembershipHandler.cs
@@ -1,0 +1,34 @@
+﻿using Commands.Extensions;
+using Commands.Services;
+
+using Domain.Interfaces;
+
+namespace Commands.Handlers.Member.ExtendMembership;
+
+public class ExtendMembershipHandler : IRequestHandler<ExtendMembershipCommand>
+{
+    private readonly IMemberRepository _repository;
+    private readonly IUserAccessor _userAccessor;
+
+    public ExtendMembershipHandler(IMemberRepository repository, IUserAccessor userAccessor)
+    {
+        _repository = repository;
+        _userAccessor = userAccessor;
+    }
+
+    public async Task<Unit> Handle(ExtendMembershipCommand request, CancellationToken cancellationToken)
+    {
+        var member = await _repository.GetById(request.Id);
+
+        if (member == null)
+            throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
+
+        var performingUser = _userAccessor.User.GetName()!;
+
+        member.ChangeMembershipExpiryDate(request.NewMembershipExpirationDate, performingUser);
+
+        await _repository.Save(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/Domain/Member.cs
+++ b/Domain/Member.cs
@@ -121,6 +121,13 @@ public class Member
         if (expiryDate == MembershipExpiryDate)
             return;
 
+        // We calculate memberships per month, so we'll use the last second of the month as an expiry date
+
+        if (expiryDate.HasValue)
+        {
+            expiryDate = expiryDate.Value.EndOfMonth();
+        }
+
         MembershipExpiryDate = expiryDate;
 
         AuditEvents.AddEvent($"Changed membership expiry date to {MembershipExpiryDate}", performedBy);
@@ -143,6 +150,6 @@ public class Member
             return true;
         }
 
-        return MembershipExpiryDate.Value.Date > DateTimeOffset.Now;
+        return MembershipExpiryDate.Value.Date >= DateTimeOffset.Now.Date;
     }
 }

--- a/Queries/Members/Handlers/AutocompleteMember/AutocompleteCounterpartyHandler.cs
+++ b/Queries/Members/Handlers/AutocompleteMember/AutocompleteCounterpartyHandler.cs
@@ -16,7 +16,7 @@ public class AutocompleteCounterpartyHandler : IRequestHandler<AutocompleteCount
     }
     public async Task<AutocompleteCounterpartyResponse> Handle(AutocompleteCounterpartyQuery request, CancellationToken cancellationToken)
     {
-        var context = _contextFactory.CreateDbContext();
+        var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
         if (request.IsMemberSearch)
         {

--- a/Types/DateTimeExtensionMethods.cs
+++ b/Types/DateTimeExtensionMethods.cs
@@ -1,0 +1,13 @@
+namespace Types;
+
+public static class DateTimeOffsetExtensionMethods
+{
+    public static DateTimeOffset StartOfMonth(this DateTimeOffset date)
+    {
+        return new DateTime(date.Year, date.Month, 1);
+    }
+    public static DateTimeOffset EndOfMonth(this DateTimeOffset date)
+    {
+        return date.StartOfMonth().AddMonths(1).AddSeconds(-1);
+    }
+}

--- a/Web/Extensions/DateTimeExtensionMethods.cs
+++ b/Web/Extensions/DateTimeExtensionMethods.cs
@@ -1,0 +1,13 @@
+namespace Web.Extensions;
+
+public static class DateTimeOffsetExtensionMethods
+{
+    public static DateTimeOffset StartOfMonth(this DateTimeOffset date)
+    {
+        return new DateTime(date.Year, date.Month, 1);
+    }
+    public static DateTimeOffset EndOfMonth(this DateTimeOffset date)
+    {
+        return date.StartOfMonth().AddMonths(1).AddSeconds(-1);
+    }
+}

--- a/Web/MapperProfiles/TransactionProfile.cs
+++ b/Web/MapperProfiles/TransactionProfile.cs
@@ -53,7 +53,8 @@ public class TransactionProfile : Profile
                     o.MapFrom(x => x.ReceivedDateTime.DateTime))
             .ForMember(x => x.Counterparty,
                 o => o.MapFrom(x => new AutocompleteCounterparty(x.CounterPartyName, x.MemberId)))
-            .ForMember(x => x.TransactionAttachments, o => o.MapFrom(x => x.TransactionAttachments));
+            .ForMember(x => x.TransactionAttachments, o => o.MapFrom(x => x.TransactionAttachments))
+            .ForMember(x => x.NewMembershipExpirationDate, o => o.Ignore());
 
         CreateMap<TransactionTypeAmount, TransactionTypeAmountForm>();
         

--- a/Web/MapperProfiles/TransactionProfile.cs
+++ b/Web/MapperProfiles/TransactionProfile.cs
@@ -10,6 +10,8 @@ using Domain;
 using Queries.Members.Handlers.AutocompleteMember;
 using Queries.Transactions.ViewModels;
 
+using Types;
+
 using Web.Models;
 
 using AttachmentFile = Commands.Handlers.AttachmentFile;
@@ -78,5 +80,8 @@ public class TransactionProfile : Profile
             .ForCtorParam(nameof(TransactionTypeAmountForm.TransactionType), o => o.MapFrom(x => x.TransactionType))
             .ForMember(x => x.Amount, o => o.MapFrom(x => x.Amount))
             .ForMember(x => x.TransactionType, o => o.MapFrom(x => x.TransactionType));
+
+
+
     }
 }

--- a/Web/Models/TransactionForm.cs
+++ b/Web/Models/TransactionForm.cs
@@ -31,12 +31,12 @@ public class TransactionForm
     public DateTime? ReceivedDateTime { get; set; }
 
     public string? Description { get; set; }
-
     [ValidateComplexType]
     public ICollection<TransactionTypeAmountForm> TransactionTypeAmounts { get; set; }
 
 
     public ICollection<TransactionAttachment> TransactionAttachments { get; set; }
+    public DateTime? NewMembershipExpirationDate { get; set; }
 }
 
 public class TransactionTypeAmountForm

--- a/Web/Pages/Members/MemberForm.razor
+++ b/Web/Pages/Members/MemberForm.razor
@@ -58,7 +58,7 @@
         <MudCardContent Class="d-flex flex-column gap-4 expand">
             <MudDatePicker AutoClose="true"
                            @bind-Date="Member.MembershipExpiryDate"
-                           DateFormat="dd/MM/yyyy"
+                           DateFormat="MM/yyyy"
                            Editable="true"
                            Label="Membership expiration date"
                            Mask="@(new DateMask("dd/MM/yyyy"))"

--- a/Web/Pages/Members/MemberForm.razor
+++ b/Web/Pages/Members/MemberForm.razor
@@ -58,10 +58,9 @@
         <MudCardContent Class="d-flex flex-column gap-4 expand">
             <MudDatePicker AutoClose="true"
                            @bind-Date="Member.MembershipExpiryDate"
-                           DateFormat="MM/yyyy"
+                           DateFormat="dd/MM/yyyy"
                            Editable="true"
                            Label="Membership expiration date"
-                           Mask="@(new DateMask("dd/MM/yyyy"))"
                            @ref="_picker">
                 <PickerActions>
                     <MudButton Class="mr-auto align-self-start"

--- a/Web/Pages/Transactions/EditTransaction.razor
+++ b/Web/Pages/Transactions/EditTransaction.razor
@@ -3,8 +3,10 @@
 @using MediatR
 @using AutoMapper
 @using Commands.Handlers
+@using Commands.Handlers.Member.ExtendMembership
 @using Commands.Handlers.Transaction.EditTransaction
 @using Domain
+@using Queries.Members.Handlers.GetMemberById
 @using Queries.Transactions.Handlers
 @using Types
 @using AttachmentFile = Commands.Handlers.AttachmentFile
@@ -81,5 +83,24 @@
         _snackbar.Clear();
         _snackbar.Add("Please correct all errors on the form", Severity.Error);
     }
-
+    private async Task ChangeMembershipFee()
+    {
+        if (!Transaction.Counterparty.MemberId.HasValue)
+        {
+            return;
+        }
+        var memberId = Transaction.Counterparty.MemberId.Value;
+        var member = await _mediator.Send(new GetMemberByIdQuery(memberId));
+        var transactionTypeForMembershipFee =
+            Transaction.TransactionTypeAmounts.SingleOrDefault(x => x.TransactionType == TransactionType.DebitMemberFee);
+        if (transactionTypeForMembershipFee != null && transactionTypeForMembershipFee.Amount != 0)
+        {
+            var amountOfMonths = (int)Math.Floor((double)transactionTypeForMembershipFee.Amount / member.MembershipFee);
+            if (member.MembershipExpiryDate.HasValue)
+            {
+                //Transaction.NewExpirationDate = member.MembershipExpiryDate.Value.AddMonths(amountOfMonths).Date;
+                //await _mediator.Send(new ExtendMembershipCommand(memberId, _newExpirationDate));
+            }
+        }
+    }
 }

--- a/Web/Pages/Transactions/EditTransaction.razor
+++ b/Web/Pages/Transactions/EditTransaction.razor
@@ -1,19 +1,14 @@
 ﻿@page "/transactions/{TransactionId:guid}/edit"
 @attribute [Authorize]
-@using MediatR
-@using AutoMapper
-@using Commands.Handlers
 @using Commands.Handlers.Member.ExtendMembership
 @using Commands.Handlers.Transaction.EditTransaction
 @using Domain
-@using Queries.Members.Handlers.GetMemberById
 @using Queries.Transactions.Handlers
-@using Types
 @using AttachmentFile = Commands.Handlers.AttachmentFile
-@inject IMediator _mediator
-@inject IMapper _mapper
-@inject ISnackbar _snackbar
-@inject NavigationManager _navManager
+@inject IMediator Mediator
+@inject IMapper Mapper
+@inject ISnackbar Snackbar
+@inject NavigationManager NavManager
 
 <h1 class="my-6">Edit transaction</h1>
 
@@ -51,8 +46,8 @@
     protected override async Task OnInitializedAsync()
     {
         var query = new GetTransactionByIdQuery(TransactionId);
-        var transactionDetail = await _mediator.Send(query);
-        Transaction = _mapper.Map<Models.TransactionForm>(transactionDetail);
+        var transactionDetail = await Mediator.Send(query);
+        Transaction = Mapper.Map<Models.TransactionForm>(transactionDetail);
         _transactionTypeGroup = TransactionTypes.GetTransactionTypeGroup(Transaction.TransactionTypeAmounts.First().TransactionType);
     }
 
@@ -60,6 +55,8 @@
 
     private async Task SubmitTransaction()
     {
+        var memberId = Transaction.Counterparty.MemberId;
+        var expirationDate = Transaction.NewMembershipExpirationDate;
         var command = new EditTransactionCommand(
             Id: TransactionId,
             CounterPartyName: Transaction.Counterparty.Name!,
@@ -72,35 +69,19 @@
                 .ToList(),
             AttachmentFiles: new List<AttachmentFile>()
             );
-        var response = await _mediator.Send(command);
-        _snackbar.Clear();
-        _snackbar.Add("Transaction edited successfully!", Severity.Success);
-        _navManager.NavigateTo("/transactions");
+        var response = await Mediator.Send(command);
+        if (memberId.HasValue && expirationDate.HasValue)
+        {
+            await Mediator.Send(new ExtendMembershipCommand(memberId.Value, expirationDate.Value));
+        }
+        Snackbar.Clear();
+        Snackbar.Add("Transaction edited successfully!", Severity.Success);
+        NavManager.NavigateTo("/transactions");
     }
 
     private void ShowError()
     {
-        _snackbar.Clear();
-        _snackbar.Add("Please correct all errors on the form", Severity.Error);
-    }
-    private async Task ChangeMembershipFee()
-    {
-        if (!Transaction.Counterparty.MemberId.HasValue)
-        {
-            return;
-        }
-        var memberId = Transaction.Counterparty.MemberId.Value;
-        var member = await _mediator.Send(new GetMemberByIdQuery(memberId));
-        var transactionTypeForMembershipFee =
-            Transaction.TransactionTypeAmounts.SingleOrDefault(x => x.TransactionType == TransactionType.DebitMemberFee);
-        if (transactionTypeForMembershipFee != null && transactionTypeForMembershipFee.Amount != 0)
-        {
-            var amountOfMonths = (int)Math.Floor((double)transactionTypeForMembershipFee.Amount / member.MembershipFee);
-            if (member.MembershipExpiryDate.HasValue)
-            {
-                //Transaction.NewExpirationDate = member.MembershipExpiryDate.Value.AddMonths(amountOfMonths).Date;
-                //await _mediator.Send(new ExtendMembershipCommand(memberId, _newExpirationDate));
-            }
-        }
+        Snackbar.Clear();
+        Snackbar.Add("Please correct all errors on the form", Severity.Error);
     }
 }

--- a/Web/Pages/Transactions/NewTransaction.razor
+++ b/Web/Pages/Transactions/NewTransaction.razor
@@ -1,11 +1,10 @@
 ﻿@page "/transactions/new"
 @attribute [Authorize]
-@using MediatR
-@using AutoMapper
+@using Commands.Handlers.Member.ExtendMembership
 @using Commands.Handlers.Transaction.AddCreditTransaction
 @using Commands.Handlers.Transaction.AddDebitTransaction
-@inject IMediator _mediator
-@inject IMapper _mapper
+@inject IMediator Mediator
+@inject IMapper Mapper
 @inject ISnackbar Snackbar
 @inject NavigationManager NavManager
 
@@ -40,26 +39,33 @@
 
     private async Task AddTransaction()
     {
+        var memberId = _newTransaction.Counterparty.MemberId;
+        var expirationDate = _newTransaction.NewMembershipExpirationDate;
         switch (_selectedTransactionTypeGroup)
         {
             case TransactionTypeGroup.Credit:
             {
-                var command = _mapper.Map<AddCreditTransactionCommand>(_newTransaction);
-                await _mediator.Send(command);
+                var command = Mapper.Map<AddCreditTransactionCommand>(_newTransaction);
+                await Mediator.Send(command);
                 break;
             }
             case TransactionTypeGroup.Debit:
             {
-                var command = _mapper.Map<AddDebitTransactionCommand>(_newTransaction);
-                await _mediator.Send(command);
+                var command = Mapper.Map<AddDebitTransactionCommand>(_newTransaction);
+                await Mediator.Send(command);
                 break;
             }
         }
-
+        if (memberId.HasValue && expirationDate.HasValue)
+        {
+            await Mediator.Send(new ExtendMembershipCommand(memberId.Value, expirationDate.Value));
+        }
         Snackbar.Clear();
         Snackbar.Add($"Transaction for {_newTransaction.Counterparty.Name} added successfully!", Severity.Success);
         NavManager.NavigateTo("/transactions");
     }
+
+    
 
     private void ShowError()
     {
@@ -67,4 +73,5 @@
         Snackbar.Add("Please correct all errors on the form", Severity.Error);
     }
 
+   
 }

--- a/Web/Pages/Transactions/TransactionForm.razor
+++ b/Web/Pages/Transactions/TransactionForm.razor
@@ -197,24 +197,16 @@
         </MudText>
         @if (CanExtendMembership && SelectedMember != null)
         {
-            <MudDivider Class="my-2"></MudDivider>
-            <MudText>Extend membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths more month(s) of membership</MudText>
+            <MudCheckBox Color="Color.Secondary" @bind-Checked="_applyMembershipCalculation">Extend membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths more month(s) of membership</MudCheckBox>
+            
             <MudGrid>
-                <MudItem xs="6">
-                    <MudDatePicker Label="New expiration month" 
-                                   @bind-Date="_newExpirationDate" 
-                                   DisableToolbar="true"
-                                   OpenTo="OpenTo.Month" 
-                                   DateFormat="MM/yyyy"
-                                   MinDate="DateTime.Today"
-                                   FixDay="@DateTime.Today.Day"/>
-                </MudItem>
-                <MudItem xs="6">
-                    <MudButton 
-                        Size="Size.Small"
-                        Variant="Variant.Filled"
-                        Color="Color.Secondary" OnClick="ChangeMembershipFee">Change membership expiration date</MudButton>
-                </MudItem>
+                <MudDatePicker Label="New expiration month" 
+                               @bind-Date="_newExpirationDate" 
+                               DisableToolbar="true"
+                               OpenTo="OpenTo.Month" 
+                               DateFormat="MM/yyyy"
+                               MinDate="DateTime.Today"
+                               FixDay="@DateTime.Today.Day"/>
             </MudGrid>
         }
         
@@ -305,7 +297,7 @@
     private int AmountOfMonths { get; set; }
 
     private MemberDetail? SelectedMember { get; set; }
-
+    
     private bool CanExtendMembership =>
         Transaction.TransactionTypeAmounts.Any(x => x.TransactionType == TransactionType.DebitMemberFee) &&
         Transaction.Counterparty.MemberId.HasValue;
@@ -416,15 +408,7 @@
         transactionTypeAmount.Amount = value;
         await CalculateMembershipExpirationDate();
     }
-
-    private async Task ChangeMembershipFee()
-    {
-        if (!Transaction.Counterparty.MemberId.HasValue || SelectedMember == null || _newExpirationDate == null)
-        {
-            return;
-        }
-        await mediator.Send(new ExtendMembershipCommand(SelectedMember.Id, _newExpirationDate.Value));
-    }
+    
 
     private async Task CalculateMembershipExpirationDate()
     {
@@ -443,9 +427,9 @@
         {
             AmountOfMonths = (int)Math.Floor((double)transactionTypeForMembershipFee.Amount / SelectedMember.MembershipFee);
             _newExpirationDate = SelectedMember.MembershipExpiryDate.Value.AddMonths(AmountOfMonths).Date;
+            Transaction.NewMembershipExpirationDate = _newExpirationDate;
         }
     }
 
-
-
+    private bool _applyMembershipCalculation;
 }

--- a/Web/Pages/Transactions/TransactionForm.razor
+++ b/Web/Pages/Transactions/TransactionForm.razor
@@ -5,8 +5,12 @@
 @using Queries.Members.Handlers.SearchMembers
 @using Web.Models
 @using Commands.Handlers.BankAccount
+@using Commands.Handlers.Member.ExtendMembership
 @using Commands.Handlers.Transaction.GetAttachment
 @using LinqKit
+@using Queries.Members.Handlers.GetMemberById
+@using Queries.Members.ViewModels
+@using System.Windows.Input
 
 @inject IWebHostEnvironment Environment
 
@@ -60,9 +64,10 @@
             <MudItem xs="3">
                 @if (IsSearchForMembership)
                 {
-                    <MudAutocomplete @bind-Value="Transaction.Counterparty"
+                    <MudAutocomplete ValueChanged="OnChangeMember"
                                      Label="Members"
                                      SearchFunc="SearchForMembers"
+                                     Value="Transaction.Counterparty"
                                      T="AutocompleteCounterparty"
                                      ToStringFunc="ac => ac?.Name"
                                      Variant="Variant.Outlined">
@@ -165,7 +170,8 @@
             @foreach (var transactionType in Transaction.TransactionTypeAmounts)
             {
                 <MudItem xs="6">
-                    <MudNumericField @bind-Value="transactionType.Amount"
+                    <MudNumericField Value="transactionType.Amount"
+                                     ValueChanged="(value) => OnAmountChanged(transactionType, value)"
                                      Label="Amount (€)"
                                      Min="0"
                                      T="decimal">
@@ -189,6 +195,29 @@
             Sum of all types: <strong>€@Transaction.TransactionTypeAmounts.Sum(x => x.Amount)</strong>.
             This value should match the total amount of the transaction
         </MudText>
+        @if (CanExtendMembership && SelectedMember != null)
+        {
+            <MudDivider Class="my-2"></MudDivider>
+            <MudText>Extend membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths more month(s) of membership</MudText>
+            <MudGrid>
+                <MudItem xs="6">
+                    <MudDatePicker Label="New expiration month" 
+                                   @bind-Date="_newExpirationDate" 
+                                   DisableToolbar="true"
+                                   OpenTo="OpenTo.Month" 
+                                   DateFormat="MM/yyyy"
+                                   MinDate="DateTime.Today"
+                                   FixDay="@DateTime.Today.Day"/>
+                </MudItem>
+                <MudItem xs="6">
+                    <MudButton 
+                        Size="Size.Small"
+                        Variant="Variant.Filled"
+                        Color="Color.Secondary" OnClick="ChangeMembershipFee">Change membership expiration date</MudButton>
+                </MudItem>
+            </MudGrid>
+        }
+        
     </MudCardContent>
 </MudCard>
 <MudCard class="mb-6 mt-2 pb-3 expand">
@@ -271,20 +300,31 @@
 
     private IReadOnlyList<TransactionType> _transactionTypes = new List<TransactionType>();
 
+    private DateTime? _newExpirationDate;
+
+    private int AmountOfMonths { get; set; }
+
+    private MemberDetail? SelectedMember { get; set; }
+
+    private bool CanExtendMembership =>
+        Transaction.TransactionTypeAmounts.Any(x => x.TransactionType == TransactionType.DebitMemberFee) &&
+        Transaction.Counterparty.MemberId.HasValue;
+
     protected override async Task OnInitializedAsync()
     {
         await GetAllBankAccounts();
         _transactionTypes = TransactionTypes.GetScopedTransactionTypes(TransactionTypeGroup);
     }
-
-    
-
     MudDatePicker _picker = new();
     private int _maxAllowedSize = 1024 * 1024 * 10;
     private IReadOnlyList<string> _allowedFileTypes = new List<string> { "pdf", "doc", "docx", "jpg", "jpeg", "png", "gif" };
 
     private async Task<IEnumerable<AutocompleteCounterparty>> SearchForMembers(string searchString)
     {
+        if (string.IsNullOrEmpty(searchString))
+        {
+            return new List<AutocompleteCounterparty>();
+        }
         var response = await mediator.Send(new AutocompleteCounterpartyQuery(searchString, true));
         return response.Counterparties;
     }
@@ -314,11 +354,6 @@
         {
             await GetAllBankAccounts();
         }
-    }
-
-    private void TransactionTypeChanged()
-    {
-        _transactionTypes = TransactionTypes.GetScopedTransactionTypes(TransactionTypeGroup);
     }
 
     Converter<AutocompleteCounterparty> counterPartyConverter = new Converter<AutocompleteCounterparty>
@@ -369,5 +404,48 @@
         using var streamRef = new DotNetStreamReference(fileStream);
         await JS.InvokeVoidAsync("downloadFileFromStream", attachment.Name, streamRef); // THIS FEELS SOOOO DIRTY
     }
+
+    private async Task OnChangeMember(AutocompleteCounterparty counterparty)
+    {
+        Transaction.Counterparty = counterparty;
+        await CalculateMembershipExpirationDate();
+    }
+
+    private async Task OnAmountChanged(TransactionTypeAmountForm transactionTypeAmount, decimal value)
+    {
+        transactionTypeAmount.Amount = value;
+        await CalculateMembershipExpirationDate();
+    }
+
+    private async Task ChangeMembershipFee()
+    {
+        if (!Transaction.Counterparty.MemberId.HasValue || SelectedMember == null || _newExpirationDate == null)
+        {
+            return;
+        }
+        await mediator.Send(new ExtendMembershipCommand(SelectedMember.Id, _newExpirationDate.Value));
+    }
+
+    private async Task CalculateMembershipExpirationDate()
+    {
+        if (!Transaction.Counterparty.MemberId.HasValue)
+        {
+            return;
+        }
+        var memberId = Transaction.Counterparty.MemberId.Value;
+        var member = await mediator.Send(new GetMemberByIdQuery(memberId));
+        SelectedMember = member;
+        var transactionTypeForMembershipFee =
+            Transaction.TransactionTypeAmounts.SingleOrDefault(x => x.TransactionType == TransactionType.DebitMemberFee);
+        if (transactionTypeForMembershipFee != null && 
+            transactionTypeForMembershipFee.Amount != 0 && 
+            SelectedMember.MembershipExpiryDate.HasValue)
+        {
+            AmountOfMonths = (int)Math.Floor((double)transactionTypeForMembershipFee.Amount / SelectedMember.MembershipFee);
+            _newExpirationDate = SelectedMember.MembershipExpiryDate.Value.AddMonths(AmountOfMonths).Date;
+        }
+    }
+
+
 
 }

--- a/Web/Pages/Transactions/TransactionTypeGroup.cs
+++ b/Web/Pages/Transactions/TransactionTypeGroup.cs
@@ -1,10 +1,9 @@
 ﻿using System.ComponentModel;
 
-namespace Web.Pages.Transactions
+namespace Web.Pages.Transactions;
+
+public enum TransactionTypeGroup
 {
-    public enum TransactionTypeGroup
-    {
-        [Description("Debit")] Debit,
-        [Description("Credit")] Credit
-    }
+    [Description("Debit")] Debit,
+    [Description("Credit")] Credit
 }

--- a/Web/Pages/Transactions/Transactions.razor
+++ b/Web/Pages/Transactions/Transactions.razor
@@ -1,11 +1,8 @@
 @page "/transactions"
 @attribute [Authorize]
-
-@using MediatR
 @using Queries.Transactions.Handlers
 @using Queries.Transactions.ViewModels
 @using Types
-@using Domain
 @using TransactionTypeAmount = Queries.Transactions.ViewModels.TransactionTypeAmount
 
 @inject IMediator _mediator


### PR DESCRIPTION
This feature adds a new form when:
- creating a new transaction and selecting the membership fee
- editing a transaction and changing the membership fee, member or the amount of the membership fee

The form calculates the amount of months will be added to the current expiration date, based on the amount of the membership fee.

Additionally, we set the expiration date to the end of the month (when it is set).

What could be done better?
It's now required to change the expiration date explicitly, by clicking on the button. It would be better/easier to just change it by clicking on the "Add" or "Save" button at the button of the page.