### PR TITLE
#fix: When unchecked, don't take extended date into account

### DIFF
--- a/Queries/MapperProfiles/TransactionProfile.cs
+++ b/Queries/MapperProfiles/TransactionProfile.cs
@@ -8,38 +8,37 @@ using Queries.Transactions.ViewModels;
 using TransactionAttachment = Domain.TransactionAttachment;
 using TransactionTypeAmount = Domain.TransactionTypeAmount;
 
-namespace Queries.MapperProfiles
+namespace Queries.MapperProfiles;
+
+public class TransactionProfile : Profile
 {
-    public class TransactionProfile : Profile
+    public TransactionProfile()
     {
-        public TransactionProfile()
-        {
-            CreateMap<Transaction, TransactionSummary>();
+        CreateMap<Transaction, TransactionSummary>();
 
-            CreateMap<Transaction, TransactionDetail>()
-                .ForCtorParam(nameof(TransactionDetail.TransactionTypeAmounts),
-                    o => o.MapFrom(x => x.TransactionTypeAmounts))
-                .ForMember(x => x.TransactionTypeAmounts, o => o.MapFrom(x => x.TransactionTypeAmounts))
-                .ForCtorParam(nameof(TransactionDetail.TransactionAttachments), o => o.MapFrom(x => x.Attachments))
-                .ForMember(x => x.TransactionAttachments, o => o.MapFrom(x => x.Attachments))
-                .ForCtorParam(nameof(TransactionDetail.Id), o => o.MapFrom(x => x.Id))
-                .ForCtorParam(nameof(TransactionDetail.Amount), o => o.MapFrom(x => x.Amount))
-                .ForCtorParam(nameof(TransactionDetail.BankAccountId), o => o.MapFrom(x => x.BankAccountId))
-                .ForCtorParam(nameof(TransactionDetail.CounterPartyName), o => o.MapFrom(x => x.CounterPartyName))
-                .ForCtorParam(nameof(TransactionDetail.Description), o => o.MapFrom(x => x.Description))
-                .ForCtorParam(nameof(TransactionDetail.MemberId), o => o.MapFrom(x => x.MemberId))
-                .ForCtorParam(nameof(TransactionDetail.ReceivedDateTime), o => o.MapFrom(x => x.ReceivedDateTime));
+        CreateMap<Transaction, TransactionDetail>()
+            .ForCtorParam(nameof(TransactionDetail.TransactionTypeAmounts),
+                o => o.MapFrom(x => x.TransactionTypeAmounts))
+            .ForMember(x => x.TransactionTypeAmounts, o => o.MapFrom(x => x.TransactionTypeAmounts))
+            .ForCtorParam(nameof(TransactionDetail.TransactionAttachments), o => o.MapFrom(x => x.Attachments))
+            .ForMember(x => x.TransactionAttachments, o => o.MapFrom(x => x.Attachments))
+            .ForCtorParam(nameof(TransactionDetail.Id), o => o.MapFrom(x => x.Id))
+            .ForCtorParam(nameof(TransactionDetail.Amount), o => o.MapFrom(x => x.Amount))
+            .ForCtorParam(nameof(TransactionDetail.BankAccountId), o => o.MapFrom(x => x.BankAccountId))
+            .ForCtorParam(nameof(TransactionDetail.CounterPartyName), o => o.MapFrom(x => x.CounterPartyName))
+            .ForCtorParam(nameof(TransactionDetail.Description), o => o.MapFrom(x => x.Description))
+            .ForCtorParam(nameof(TransactionDetail.MemberId), o => o.MapFrom(x => x.MemberId))
+            .ForCtorParam(nameof(TransactionDetail.ReceivedDateTime), o => o.MapFrom(x => x.ReceivedDateTime));
 
 
-            CreateMap<TransactionAttachment, Queries.Transactions.ViewModels.TransactionAttachment>()
-                .ForCtorParam(nameof(Transactions.ViewModels.TransactionAttachment.Name), o => o.MapFrom(x => x.Name))
-                .ForCtorParam(nameof(Transactions.ViewModels.TransactionAttachment.FullPath), o => o.MapFrom(x => x.FullPath));
-            CreateMap<TransactionTypeAmount, Queries.Transactions.ViewModels.TransactionTypeAmount>()
-                .ForCtorParam(nameof(Transactions.ViewModels.TransactionTypeAmount.Amount),
-                    o => o.MapFrom(x => x.Amount))
-                .ForCtorParam(nameof(Transactions.ViewModels.TransactionTypeAmount.TransactionType),
-                    o => o.MapFrom(x => x.TransactionType));
+        CreateMap<TransactionAttachment, Queries.Transactions.ViewModels.TransactionAttachment>()
+            .ForCtorParam(nameof(Transactions.ViewModels.TransactionAttachment.Name), o => o.MapFrom(x => x.Name))
+            .ForCtorParam(nameof(Transactions.ViewModels.TransactionAttachment.FullPath), o => o.MapFrom(x => x.FullPath));
+        CreateMap<TransactionTypeAmount, Queries.Transactions.ViewModels.TransactionTypeAmount>()
+            .ForCtorParam(nameof(Transactions.ViewModels.TransactionTypeAmount.Amount),
+                o => o.MapFrom(x => x.Amount))
+            .ForCtorParam(nameof(Transactions.ViewModels.TransactionTypeAmount.TransactionType),
+                o => o.MapFrom(x => x.TransactionType));
             
-        }
     }
 }

--- a/Web/MapperProfiles/TransactionProfile.cs
+++ b/Web/MapperProfiles/TransactionProfile.cs
@@ -54,7 +54,8 @@ public class TransactionProfile : Profile
             .ForMember(x => x.Counterparty,
                 o => o.MapFrom(x => new AutocompleteCounterparty(x.CounterPartyName, x.MemberId)))
             .ForMember(x => x.TransactionAttachments, o => o.MapFrom(x => x.TransactionAttachments))
-            .ForMember(x => x.NewMembershipExpirationDate, o => o.Ignore());
+            .ForMember(x => x.NewMembershipExpirationDate, o => o.Ignore())
+            .ForMember(x => x.ApplyMembershipCalculation, o => o.Ignore());
 
         CreateMap<TransactionTypeAmount, TransactionTypeAmountForm>();
         

--- a/Web/Models/TransactionForm.cs
+++ b/Web/Models/TransactionForm.cs
@@ -39,6 +39,7 @@ public class TransactionForm
 
     public ICollection<TransactionAttachment> TransactionAttachments { get; set; }
     public DateTime? NewMembershipExpirationDate { get; set; }
+    public bool ApplyMembershipCalculation { get; set; }
 }
 
 public class TransactionTypeAmountForm

--- a/Web/Pages/Transactions/EditTransaction.razor
+++ b/Web/Pages/Transactions/EditTransaction.razor
@@ -55,6 +55,7 @@
     {
         var memberId = Transaction.Counterparty.MemberId;
         var expirationDate = Transaction.NewMembershipExpirationDate;
+        var applyCalculation = Transaction.ApplyMembershipCalculation;
         var command = new EditTransactionCommand(
             Id: TransactionId,
             CounterPartyName: Transaction.Counterparty.Name!,
@@ -68,7 +69,7 @@
             AttachmentFiles: new List<AttachmentFile>()
             );
         var response = await Mediator.Send(command);
-        if (memberId.HasValue && expirationDate.HasValue)
+        if (memberId.HasValue && expirationDate.HasValue && applyCalculation)
         {
             await Mediator.Send(new ExtendMembershipCommand(memberId.Value, expirationDate.Value));
         }

--- a/Web/Pages/Transactions/NewTransaction.razor
+++ b/Web/Pages/Transactions/NewTransaction.razor
@@ -56,7 +56,7 @@
                 break;
             }
         }
-        if (memberId.HasValue && expirationDate.HasValue)
+        if (memberId.HasValue && expirationDate.HasValue && _newTransaction.ApplyMembershipCalculation)
         {
             await Mediator.Send(new ExtendMembershipCommand(memberId.Value, expirationDate.Value));
         }

--- a/Web/Pages/Transactions/NewTransaction.razor
+++ b/Web/Pages/Transactions/NewTransaction.razor
@@ -41,6 +41,7 @@
     {
         var memberId = _newTransaction.Counterparty.MemberId;
         var expirationDate = _newTransaction.NewMembershipExpirationDate;
+        var newTransactionApplyMembershipCalculation = _newTransaction.ApplyMembershipCalculation;
         switch (_selectedTransactionTypeGroup)
         {
             case TransactionTypeGroup.Credit:
@@ -56,7 +57,7 @@
                 break;
             }
         }
-        if (memberId.HasValue && expirationDate.HasValue && _newTransaction.ApplyMembershipCalculation)
+        if (memberId.HasValue && expirationDate.HasValue && newTransactionApplyMembershipCalculation)
         {
             await Mediator.Send(new ExtendMembershipCommand(memberId.Value, expirationDate.Value));
         }

--- a/Web/Pages/Transactions/TransactionForm.razor
+++ b/Web/Pages/Transactions/TransactionForm.razor
@@ -200,7 +200,7 @@
         </MudText>
         @if (CanExtendMembership && SelectedMember != null)
         {
-            <MudCheckBox Color="Color.Secondary" @bind-Checked="_applyMembershipCalculation">Extend membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths more month(s) of membership</MudCheckBox>
+            <MudCheckBox Color="Color.Secondary" @bind-Checked="Transaction.ApplyMembershipCalculation">Extend membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths more month(s) of membership</MudCheckBox>
             
             <MudGrid>
                 <MudDatePicker Label="New expiration month" 
@@ -436,5 +436,4 @@
         }
     }
 
-    private bool _applyMembershipCalculation;
 }


### PR DESCRIPTION
When the "Extend membership expiration date" is left unchecked in the transaction form, the date would still be extended.
This PR fixes that.