### PR TITLE
fix: Don't override Counterparty

### DIFF
--- a/Web/Pages/Transactions/TransactionForm.razor
+++ b/Web/Pages/Transactions/TransactionForm.razor
@@ -296,7 +296,6 @@
     private void SetTransactionTypes()
     {
         _transactionTypes = TransactionTypes.GetScopedTransactionTypes(TransactionTypeGroup);
-        Transaction.Counterparty = new AutocompleteCounterparty(string.Empty, null);
     }
 
     MudDatePicker _picker = new();


### PR DESCRIPTION
In the upgrade to .NET7 some getters and setters were changed, correctly. However, in doing so setting the counterparty got overridden.