### PR TITLE
fix: Allow uploading files when editting a transaction

### DIFF
--- a/Web/Pages/Transactions/EditTransaction.razor
+++ b/Web/Pages/Transactions/EditTransaction.razor
@@ -65,8 +65,10 @@
             TransactionTypeAmounts: Transaction.TransactionTypeAmounts
                 .Select(x => new TransactionTypeAmount(x.TransactionType!.Value, x.Amount!.Value))
                 .ToList(),
-            AttachmentFiles: new List<AttachmentFile>()
-            );
+            AttachmentFiles: Transaction.TransactionAttachments
+                .Select(x => new AttachmentFile(x.FileName, x.ContentType, x.UnsafePath))
+                .ToList()
+                );
         var response = await Mediator.Send(command);
         if (memberId.HasValue && expirationDate.HasValue)
         {


### PR DESCRIPTION
When editting a transaction, adding a transaction doesn't work.

This is correct, because it was never implemented.

This PR allows to add attachments to a transaction.