### PR TITLE
Duplicate members

### DIFF
--- a/Commands/Handlers/EditBankAccount/EditBankAccountHandler.cs
+++ b/Commands/Handlers/EditBankAccount/EditBankAccountHandler.cs
@@ -18,11 +18,8 @@ public class EditBankAccountHandler : IRequestHandler<EditBankAccountCommand, Gu
 
     public async Task<Guid> Handle(EditBankAccountCommand request, CancellationToken cancellationToken)
     {
-        var bankAccount = await _repository.GetByIdAsync(request.Id, cancellationToken);
-        if (bankAccount is null)
-        {
-            throw new ArgumentException($"No bankaccount found for Id {request.Id}", nameof(request.Id));
-        }
+        var bankAccount = await _repository.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new ArgumentException($"No bankaccount found for Id {request.Id}", nameof(request.Id));
 
         var performingUser = _userAccessor.User.GetName()!;
 

--- a/Commands/Handlers/Member/DeleteMember/DeleteMemberCommand.cs
+++ b/Commands/Handlers/Member/DeleteMember/DeleteMemberCommand.cs
@@ -15,10 +15,8 @@ public class DeleteMemberHandler : IRequestHandler<DeleteMemberCommand>
 
     public async Task Handle(DeleteMemberCommand request, CancellationToken cancellationToken)
     {
-        var member = await _memberRepository.GetById(request.Id);
-
-        if (member == null)
-            throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
+        var member = await _memberRepository.GetById(request.Id)
+            ?? throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
 
         _memberRepository.Remove(member);
 

--- a/Commands/Handlers/Member/EditMember/EditMemberHandler.cs
+++ b/Commands/Handlers/Member/EditMember/EditMemberHandler.cs
@@ -3,25 +3,31 @@ using Commands.Services;
 
 using Domain.Interfaces;
 
+using Microsoft.EntityFrameworkCore;
+
+using Persistence;
+
 namespace Commands.Handlers.Member.EditMember;
 
 public class EditMemberHandler : IRequestHandler<EditMemberCommand>
 {
     private readonly IMemberRepository _memberRepository;
     private readonly IUserAccessor _userAccessor;
+    private readonly HaSpManContext _dbContext;
 
-    public EditMemberHandler(IMemberRepository memberRepository, IUserAccessor userAccessor)
+    public EditMemberHandler(IMemberRepository memberRepository, IUserAccessor userAccessor, HaSpManContext dbContext)
     {
         _memberRepository = memberRepository;
         _userAccessor = userAccessor;
+        _dbContext = dbContext;
     }
 
     public async Task Handle(EditMemberCommand request, CancellationToken cancellationToken)
     {
-        var member = await _memberRepository.GetById(request.Id);
+        var member = await _memberRepository.GetById(request.Id)
+            ?? throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
 
-        if (member == null)
-            throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
+        await EnsureMemberIsNotBecomeDuplicate(request, cancellationToken);
 
         var performingUser = _userAccessor.User.GetName()!;
         member.ChangeAddress(request.Address, performingUser);
@@ -32,5 +38,30 @@ public class EditMemberHandler : IRequestHandler<EditMemberCommand>
         member.ChangePhoneNumber(request.PhoneNumber, performingUser);
 
         await _memberRepository.Save(cancellationToken);
+    }
+
+    private async Task EnsureMemberIsNotBecomeDuplicate(EditMemberCommand command, CancellationToken ct)
+    {
+        var memberExistsByEmail = await _dbContext.Members
+            .AsNoTracking()
+            .AnyAsync(m => m.Id != command.Id && m.Email == command.Email, ct);
+
+        if (memberExistsByEmail)
+            throw new InvalidOperationException("Can't add member with same email address as existing member");
+
+        var memberExistsByNameAndAddress = await _dbContext.Members
+            .AsNoTracking()
+            .AnyAsync(m =>
+                m.Id != command.Id
+                && m.FirstName == command.FirstName
+                && m.LastName == command.LastName
+                && m.Address.Street == command.Address.Street
+                && m.Address.City == command.Address.City
+                && m.Address.Country == command.Address.Country
+                && m.Address.ZipCode == command.Address.ZipCode
+                && m.Address.HouseNumber == command.Address.HouseNumber, ct);
+
+        if (memberExistsByNameAndAddress)
+            throw new InvalidOperationException("Can't add member with same name and address as existing member");
     }
 }

--- a/Commands/Handlers/Member/ExtendMembership/ExtendMembershipHandler.cs
+++ b/Commands/Handlers/Member/ExtendMembership/ExtendMembershipHandler.cs
@@ -18,10 +18,8 @@ public class ExtendMembershipHandler : IRequestHandler<ExtendMembershipCommand>
 
     public async Task Handle(ExtendMembershipCommand request, CancellationToken cancellationToken)
     {
-        var member = await _repository.GetById(request.Id);
-
-        if (member == null)
-            throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
+        var member = await _repository.GetById(request.Id)
+            ?? throw new ArgumentException($"No member found by Id {request.Id}", nameof(request.Id));
 
         var performingUser = _userAccessor.User.GetName()!;
 

--- a/Commands/Handlers/Transaction/AddAttachments/AddAttachmentsCommand.cs
+++ b/Commands/Handlers/Transaction/AddAttachments/AddAttachmentsCommand.cs
@@ -41,12 +41,9 @@ public class AddAttachmentsHandler : IRequestHandler<AddAttachmentsCommand, Unit
 
     public async Task<Unit> Handle(AddAttachmentsCommand request, CancellationToken cancellationToken)
     {
-        var transaction = await _transactionRepository.GetByIdAsync(request.TransactionId, cancellationToken);
-        if (transaction == null)
-        {
-            throw new ArgumentException($"No transaction found for Id {request.TransactionId}", nameof(request.TransactionId));
-        }
-        
+        var transaction = await _transactionRepository.GetByIdAsync(request.TransactionId, cancellationToken)
+            ?? throw new ArgumentException($"No transaction found for Id {request.TransactionId}", nameof(request.TransactionId));
+
         var transactionAttachments = await StoreAttachmentsAsync(request, cancellationToken);
         
         transaction.AddAttachments(transactionAttachments);

--- a/Commands/Handlers/Transaction/EditTransaction/EditTransactionHandler.cs
+++ b/Commands/Handlers/Transaction/EditTransaction/EditTransactionHandler.cs
@@ -18,11 +18,8 @@ public class EditTransactionHandler : IRequestHandler<EditTransactionCommand, Gu
     }
     public async Task<Guid> Handle(EditTransactionCommand request, CancellationToken cancellationToken)
     {
-        var transaction = await _transactionRepository.GetByIdAsync(request.Id, cancellationToken);
-        if (transaction == null)
-        {
-            throw new ArgumentException($"No transaction found for Id {request.Id}", nameof(request.Id));
-        }
+        var transaction = await _transactionRepository.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new ArgumentException($"No transaction found for Id {request.Id}", nameof(request.Id));
 
 
         var totalAmount = request.TransactionTypeAmounts.Sum(x => x.Amount);

--- a/Commands/Services/UserAccessor.cs
+++ b/Commands/Services/UserAccessor.cs
@@ -6,7 +6,7 @@ namespace Commands.Services;
 
 public class UserAccessor : IUserAccessor
 {
-    private IHttpContextAccessor _accessor;
+    private readonly IHttpContextAccessor _accessor;
     public UserAccessor(IHttpContextAccessor accessor)
     {
         _accessor = accessor ?? throw new ArgumentException("Valid IHttpContextAccessor is needed", nameof(accessor));

--- a/Domain/Member.cs
+++ b/Domain/Member.cs
@@ -145,11 +145,7 @@ public class Member
 
     public bool IsActive()
     {
-        if (MembershipExpiryDate == null)
-        {
-            return true;
-        }
-
-        return MembershipExpiryDate.Value.Date >= DateTimeOffset.Now.Date;
+        return MembershipExpiryDate == null
+            || MembershipExpiryDate.Value.Date >= DateTimeOffset.Now.Date;
     }
 }

--- a/Persistence/EntityConfigurations/TransactionConfigurations.cs
+++ b/Persistence/EntityConfigurations/TransactionConfigurations.cs
@@ -28,7 +28,7 @@ public class CreditTransactionConfiguration : IEntityTypeConfiguration<CreditTra
 
     }
 
-    private Action<OwnedNavigationBuilder<CreditTransaction, TransactionTypeAmount>> TransactionTypeAmountConfiguration(string tableName)
+    private static Action<OwnedNavigationBuilder<CreditTransaction, TransactionTypeAmount>> TransactionTypeAmountConfiguration(string tableName)
     {
         return cfg =>
         {

--- a/Queries/BankAccounts/SearchBankAccounts.cs
+++ b/Queries/BankAccounts/SearchBankAccounts.cs
@@ -65,6 +65,7 @@ public class SearchBankAccountsHandler : IRequestHandler<SearchBankAccountsQuery
     private static IQueryable<BankAccount> GetOrderedQueryable(SearchBankAccountsQuery request, IQueryable<BankAccount> memberQueryable)
     {
         if (request.SortDirection == SortDirection.Ascending)
+        {
             memberQueryable = request.OrderBy switch
             {
                 BankAccountDetailOrderOption.Name => memberQueryable
@@ -74,8 +75,10 @@ public class SearchBankAccountsHandler : IRequestHandler<SearchBankAccountsQuery
                 _ => memberQueryable
                     .OrderBy(m => m.Name)
             };
+        }
 
         if (request.SortDirection == SortDirection.Descending)
+        {
             memberQueryable = request.OrderBy switch
             {
                 BankAccountDetailOrderOption.Name => memberQueryable
@@ -85,6 +88,8 @@ public class SearchBankAccountsHandler : IRequestHandler<SearchBankAccountsQuery
                 _ => memberQueryable
                     .OrderByDescending(m => m.Name)
             };
+        }
+
         return memberQueryable;
     }
 

--- a/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
@@ -32,12 +32,12 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
             .AsNoTracking()
             .Where(GetTextFilterCriteria(request.SearchString));
 
-        if(!request.ShowActive)
+        if (!request.ShowActive)
         {
             memberQueryable = memberQueryable.Where(m => m.MembershipExpiryDate != null && m.MembershipExpiryDate.Value.Date < DateTimeOffset.Now.Date);
         }
 
-        if(!request.ShowInactive)
+        if (!request.ShowInactive)
         {
             memberQueryable = memberQueryable.Where(m => m.MembershipExpiryDate == null || m.MembershipExpiryDate!.Value.Date >= DateTimeOffset.Now.Date);
         }

--- a/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
@@ -28,7 +28,7 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
     {
         var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
         var memberQueryable = context.Members
-           
+
             .AsNoTracking()
             .Where(GetTextFilterCriteria(request.SearchString));
 
@@ -47,7 +47,7 @@ public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginate
         var orderedQueryable = GetOrderedQueryable(request, memberQueryable);
 
         var memberSummaryQueryable = orderedQueryable
-            .Select(x => new MemberSummary(x.Id, x.Name, x.Address.ToString(), x.Email!, x.PhoneNumber!, x.IsActive(), x.MembershipExpiryDate!.Value))
+            .Select(x => new MemberSummary(x.Id, x.Name, x.Address.ToString(), x.Email!, x.PhoneNumber!, x.IsActive(), x.MembershipExpiryDate))
             .Skip(request.PageIndex * request.PageSize)
             .Take(request.PageSize);
 

--- a/Queries/Members/MemberExistsByEmailQuery.cs
+++ b/Queries/Members/MemberExistsByEmailQuery.cs
@@ -1,0 +1,32 @@
+using System.Linq.Expressions;
+
+using Domain;
+
+using Microsoft.EntityFrameworkCore;
+
+using Persistence;
+
+namespace Queries.Members;
+
+public record MemberExistsByEmailQuery(string EmailAddress, Guid? ExcludeId = null) : IRequest<bool>;
+
+public class MemberExistsByEmail : IRequestHandler<MemberExistsByEmailQuery, bool>
+{
+    private readonly HaSpManContext _dbContext;
+
+    public MemberExistsByEmail(IDbContextFactory<HaSpManContext> dbContextFactory)
+    {
+        _dbContext = dbContextFactory.CreateDbContext();
+    }
+
+    public Task<bool> Handle(MemberExistsByEmailQuery request, CancellationToken cancellationToken)
+    {
+        return _dbContext.Members
+            .AsNoTracking()
+            .AnyAsync(BuildQueryPredicate(request), cancellationToken);
+    }
+
+    private static Expression<Func<Member, bool>> BuildQueryPredicate(MemberExistsByEmailQuery request) => request.ExcludeId is null
+        ? m => m.Email == request.EmailAddress
+        : m => m.Id != request.ExcludeId && m.Email == request.EmailAddress;
+}

--- a/Queries/Members/MemberExistsByNameAndAddressQuery.cs
+++ b/Queries/Members/MemberExistsByNameAndAddressQuery.cs
@@ -1,0 +1,53 @@
+using System.Linq.Expressions;
+
+using Domain;
+
+using LinqKit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Persistence;
+
+namespace Queries.Members;
+
+public record MemberExistsByNameAndAddressQuery(
+    string FirstName,
+    string LastName,
+    string Street,
+    string HouseNumber,
+    string City,
+    string ZipCode,
+    string Country,
+    Guid? ExcludeId = null) : IRequest<bool>;
+
+public class MemberExistsByNameAndAddress : IRequestHandler<MemberExistsByNameAndAddressQuery, bool>
+{
+    private readonly HaSpManContext _dbContext;
+
+    public MemberExistsByNameAndAddress(IDbContextFactory<HaSpManContext> dbContextFactory)
+    {
+        _dbContext = dbContextFactory.CreateDbContext();
+    }
+
+    public Task<bool> Handle(MemberExistsByNameAndAddressQuery request, CancellationToken cancellationToken)
+    {
+        var queryPredicate = PredicateBuilder.New<Member>(m =>
+            m.FirstName == request.FirstName
+            && m.LastName == request.LastName
+            && m.Address.Street == request.Street
+            && m.Address.HouseNumber == request.HouseNumber
+            && m.Address.City == request.City
+            && m.Address.ZipCode == request.ZipCode
+            && m.Address.ZipCode == request.ZipCode
+            && m.Address.Country == request.Country);
+
+        if (request.ExcludeId is not null)
+        {
+            queryPredicate.And(m => m.Id != request.ExcludeId);
+        }
+
+        return _dbContext.Members
+            .AsNoTracking()
+            .AnyAsync(queryPredicate, cancellationToken);
+    }
+}

--- a/Queries/Members/ViewModels/MemberSummary.cs
+++ b/Queries/Members/ViewModels/MemberSummary.cs
@@ -7,5 +7,5 @@ public record MemberSummary(
     string Email,
     string PhoneNumber,
     bool IsActive,
-    DateTimeOffset MembershipExpiryDate
+    DateTimeOffset? MembershipExpiryDate
 );

--- a/Queries/Transactions/GetAttachment/GetAttachmentCommand.cs
+++ b/Queries/Transactions/GetAttachment/GetAttachmentCommand.cs
@@ -22,17 +22,11 @@ public class GetAttachmentHandler : IRequestHandler<GetAttachmentQuery, Attachme
     {
         
         var transactionId = request.TransactionId;
-        var transaction = await _transactionRepository.GetByIdAsync(transactionId, cancellationToken);
-        if (transaction == null)
-        {
-            throw new ArgumentException($"No transaction found for Id {request.TransactionId}", nameof(request.TransactionId));
-        }
+        var transaction = await _transactionRepository.GetByIdAsync(transactionId, cancellationToken)
+            ?? throw new ArgumentException($"No transaction found for Id {request.TransactionId}", nameof(request.TransactionId));
 
-        var attachment = transaction.Attachments.SingleOrDefault(x => x.Name == request.FileName);
-        if (attachment == null)
-        {
-            throw new ArgumentException($"No attachment found with name {request.FileName}", nameof(request.FileName));
-        }
+        var attachment = transaction.Attachments.SingleOrDefault(x => x.Name == request.FileName)
+            ?? throw new ArgumentException($"No attachment found with name {request.FileName}", nameof(request.FileName));
 
         var file = await _attachmentStorage.GetAsync(attachment.FullPath, cancellationToken);
         return file;        

--- a/Web/MapperProfiles/MemberProfile.cs
+++ b/Web/MapperProfiles/MemberProfile.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 
 using Commands.Handlers.Member.AddMember;
 
+using Queries.Members;
 using Queries.Members.ViewModels;
 
 using Types;
@@ -32,6 +33,10 @@ public class MemberProfile : Profile
             .ForMember(m => m.MembershipFee, o => o.Ignore())
             .ForMember(m => m.PhoneNumber, o => o.Ignore())
             .ForMember(m => m.Email, o => o.Ignore());
+
+        CreateMap<MemberForm, MemberExistsByNameAndAddressQuery>()
+            .ForCtorParam(nameof(MemberExistsByNameAndAddressQuery.ExcludeId), o =>
+                o.MapFrom((_, context) => context.Items[MemberProfileItems.MemberId]));
     }
     private static DateTime? ToDateTime(DateTimeOffset? dateTimeOffset)
     {
@@ -40,4 +45,9 @@ public class MemberProfile : Profile
 
         return dateTimeOffset!.Value.DateTime;
     }
+}
+
+public static class MemberProfileItems
+{
+    public const string MemberId = nameof(MemberId);
 }

--- a/Web/Pages/Members/EditMember.razor
+++ b/Web/Pages/Members/EditMember.razor
@@ -4,6 +4,8 @@
 
 @using Commands.Handlers.Member.EditMember
 @using Queries.Members.Handlers.GetMemberById
+@using Queries.Members;
+@using MapperProfiles;
 @inject IMediator _mediator
 @inject IMapper _mapper
 @inject ISnackbar Snackbar
@@ -11,18 +13,14 @@
 
 <h1 class="my-6">Edit member</h1>
 
-<EditForm Model="@member" OnValidSubmit="@SubmitMember" OnInvalidSubmit="@ShowError">
+<EditForm Model="@member" OnValidSubmit="@SubmitMember" OnInvalidSubmit="@ShowFormError">
     <DataAnnotationsValidator />
 
     <MemberForm Member="@member" />
 
     <MudItem Class="d-flex justify-start" xs="12">
-        <MudButton ButtonType="ButtonType.Submit"
-                   Class="my-8"
-                   Color="Color.Primary"
-                   DisableElevation="true"
-                   Size="Size.Large"
-                   Variant="Variant.Filled">
+        <MudButton ButtonType="ButtonType.Submit" Class="my-8" Color="Color.Primary" DisableElevation="true"
+            Size="Size.Large" Variant="Variant.Filled">
             Save member
         </MudButton>
     </MudItem>
@@ -44,6 +42,9 @@
 
     private async Task SubmitMember()
     {
+        if (await EnsureMemberDoesNotBecomeDuplicate())
+            return;
+
         var command = new EditMemberCommand(
             Id: MemberId,
             FirstName: member.FirstName!,
@@ -53,23 +54,47 @@
                 City: member.City!,
                 Country: member.Country!,
                 ZipCode: member.ZipCode!,
-                HouseNumber: member.HouseNumber!
-                ),
+                HouseNumber: member.HouseNumber!),
             Email: member.Email!,
             PhoneNumber: member.PhoneNumber!,
             MembershipFee: member.MembershipFee,
-            MembershipExpiryDate: member.MembershipExpiryDate == null ? (DateTimeOffset?)null : new
-                DateTimeOffset(member.MembershipExpiryDate!.Value)
-            );
+            MembershipExpiryDate: member.MembershipExpiryDate == null
+                ? (DateTimeOffset?)null
+                : new DateTimeOffset(member.MembershipExpiryDate!.Value));
+
         await _mediator.Send(command);
         Snackbar.Clear();
         Snackbar.Add($"Member {member.FirstName} {member.LastName} edited successfully!", Severity.Success);
         NavManager.NavigateTo("/members");
     }
 
-    private void ShowError()
+    private void ShowFormError()
+    {
+        ShowError("Please correct all errors on the form");
+    }
+
+    private void ShowError(string reason)
     {
         Snackbar.Clear();
-        Snackbar.Add("Please correct all errors on the form", Severity.Error);
+        Snackbar.Add(reason, Severity.Error);
+    }
+
+    private async Task<bool> EnsureMemberDoesNotBecomeDuplicate()
+    {
+        if (member.Email is not null && await _mediator.Send(new MemberExistsByEmailQuery(member.Email, MemberId)))
+        {
+            ShowError("Member with same email already exists");
+            return true;
+        }
+
+        var memberExistsByNameAndAddressQuery = _mapper.Map<MemberExistsByNameAndAddressQuery>(member,
+            o => o.Items[MemberProfileItems.MemberId] = MemberId);
+        if (await _mediator.Send(memberExistsByNameAndAddressQuery))
+        {
+            ShowError("Member with same name and address already exists");
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Web/Pages/Members/MemberForm.razor
+++ b/Web/Pages/Members/MemberForm.razor
@@ -90,5 +90,5 @@
     [Parameter]
     public Models.MemberForm Member { get; set; } = new();
 
-    MudDatePicker _picker = new();
+    private MudDatePicker _picker = new();
 }

--- a/Web/Pages/Members/Members.razor
+++ b/Web/Pages/Members/Members.razor
@@ -199,5 +199,6 @@
         ? Color.Success
         : Color.Error;
 
-    private string GetExpiryDate(MemberSummary member) => member.MembershipExpiryDate.Date.ToString("dd/MM/yyyy");
+    private string GetExpiryDate(MemberSummary member) => member.MembershipExpiryDate?.Date.ToString("dd/MM/yyyy")
+        ?? "Never";
 }

--- a/Web/Pages/Members/NewMember.razor
+++ b/Web/Pages/Members/NewMember.razor
@@ -3,6 +3,7 @@
 @attribute [Authorize]
 
 @using Commands.Handlers.Member.AddMember
+@using Queries.Members;
 @inject IMediator _mediator
 @inject IMapper _mapper
 @inject ISnackbar Snackbar
@@ -10,18 +11,14 @@
 
 <h1 class="my-6">Add new member</h1>
 
-<EditForm Model="@_newMember" OnValidSubmit="@AddMember" OnInvalidSubmit="@ShowError">
-   <DataAnnotationsValidator />
+<EditForm Model="@_newMember" OnValidSubmit="@AddMember" OnInvalidSubmit="@ShowFormError">
+    <DataAnnotationsValidator />
 
     <MemberForm Member="@_newMember" />
 
     <MudItem Class="d-flex justify-start" xs="12">
-        <MudButton ButtonType="ButtonType.Submit"
-                   Class="my-8"
-                   Color="Color.Primary"
-                   DisableElevation="true"
-                   Size="Size.Large"
-                   Variant="Variant.Filled">
+        <MudButton ButtonType="ButtonType.Submit" Class="my-8" Color="Color.Primary" DisableElevation="true"
+            Size="Size.Large" Variant="Variant.Filled">
             Add member
         </MudButton>
     </MudItem>
@@ -30,12 +27,15 @@
 @code {
 
     private Models.MemberForm _newMember = new()
-    {
-        Country = "Belgium"
-    };
+        {
+            Country = "Belgium"
+        };
 
     private async Task AddMember()
     {
+        if (await EnsureMemberIsNotDuplicate())
+            return;
+
         var command = _mapper.Map<AddMemberCommand>(_newMember);
         var response = await _mediator.Send(command);
         Snackbar.Clear();
@@ -43,10 +43,31 @@
         NavManager.NavigateTo("/members");
     }
 
-    private void ShowError()
+    private void ShowFormError()
     {
-        Snackbar.Clear();
-        Snackbar.Add("Please correct all errors on the form", Severity.Error);
+        ShowError("Please correct all errors on the form");
     }
 
+    private void ShowError(string error)
+    {
+        Snackbar.Clear();
+        Snackbar.Add(error, Severity.Error);
+    }
+
+    private async Task<bool> EnsureMemberIsNotDuplicate()
+    {
+        if (_newMember.Email is not null && await _mediator.Send(new MemberExistsByEmailQuery(_newMember.Email)))
+        {
+            ShowError("Member with same email already exists");
+            return true;
+        }
+
+        if (await _mediator.Send(_mapper.Map<MemberExistsByNameAndAddressQuery>(_newMember)))
+        {
+            ShowError("Member with same name and address already exists");
+            return true;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
fix: Prevent adding new members, or editing existing members, resulting in members with same email addresses or name/address combinations (fixes #155)
fix: Make members with perpetual membership (Membership expiration date is empty) work correctly
fix: Apply IDE fixes
