### PR TITLE
fix: Split handling of new and existing attachments

### DIFF
--- a/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionCommand.cs
+++ b/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionCommand.cs
@@ -14,8 +14,7 @@ public record AddCreditTransactionCommand(
     string Description,
     Guid? MemberId,
     ICollection<TransactionTypeAmount> TransactionTypeAmounts,
-    ICollection<AttachmentFile> AttachmentFiles) : IRequest<Guid>;
-
+    ICollection<AttachmentFile> NewAttachmentFiles) : IRequest<Guid>;
 
 public class AddCreditTransactionCommandValidator : AbstractValidator<AddCreditTransactionCommand>
 {
@@ -45,7 +44,7 @@ public class AddCreditTransactionCommandValidator : AbstractValidator<AddCreditT
         RuleForEach(x => x.TransactionTypeAmounts)
             .SetValidator(new TransactionTypeValidator());
 
-        RuleForEach(x => x.AttachmentFiles)
+        RuleForEach(x => x.NewAttachmentFiles)
             .SetValidator(new AttachmentValidator());
     }
 }

--- a/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionHandler.cs
+++ b/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionHandler.cs
@@ -21,12 +21,12 @@ public class AddCreditTransactionHandler : IRequestHandler<AddCreditTransactionC
     {
         var totalAmount = request.TransactionTypeAmounts.Sum(x => x.Amount);
         var transaction = new CreditTransaction(request.CounterPartyName, request.BankAccountId, totalAmount,
-            request.ReceivedDateTime, request.Description, new List<TransactionAttachment>(), request.MemberId, 
+            request.ReceivedDateTime, request.Description, new List<TransactionAttachment>(), request.MemberId,
             request.TransactionTypeAmounts);
         _transactionRepository.Add(transaction);
         await _transactionRepository.SaveAsync(cancellationToken);
 
-        await _mediator.Send(new AddAttachmentsCommand(transaction.Id, request.AttachmentFiles), cancellationToken);
+        await _mediator.Send(new AddAttachmentsCommand(transaction.Id, request.NewAttachmentFiles), cancellationToken);
 
         return transaction.Id;
     }

--- a/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionCommand.cs
+++ b/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionCommand.cs
@@ -1,4 +1,6 @@
-﻿using Domain;
+﻿using Commands.Handlers.Transaction.AddAttachments;
+
+using Domain;
 
 using FluentValidation;
 
@@ -11,7 +13,7 @@ public record AddDebitTransactionCommand(
     string Description,
     Guid? MemberId,
     ICollection<TransactionTypeAmount> TransactionTypeAmounts,
-    ICollection<AttachmentFile> AttachmentFiles) : IRequest<Guid>;
+    ICollection<AttachmentFile> NewAttachmentFiles) : IRequest<Guid>;
 
 public class AddDebitTransactionCommandValidator : AbstractValidator<AddDebitTransactionCommand>
 {
@@ -40,5 +42,8 @@ public class AddDebitTransactionCommandValidator : AbstractValidator<AddDebitTra
 
         RuleForEach(x => x.TransactionTypeAmounts)
             .SetValidator(new TransactionTypeValidator());
+
+        RuleForEach(x => x.NewAttachmentFiles)
+            .SetValidator(new AttachmentValidator());
     }
 }

--- a/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionHandler.cs
+++ b/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionHandler.cs
@@ -20,15 +20,15 @@ public class AddDebitTransactionHandler : IRequestHandler<AddDebitTransactionCom
     {
         var totalAmount = request.TransactionTypeAmounts.Sum(x => x.Amount);
         var transaction = new DebitTransaction(request.CounterPartyName, request.BankAccountId, totalAmount,
-            request.ReceivedDateTime, request.Description, new List<TransactionAttachment>(), 
-            request.MemberId, 
+            request.ReceivedDateTime, request.Description, new List<TransactionAttachment>(),
+            request.MemberId,
             request.TransactionTypeAmounts);
 
         _transactionRepository.Add(transaction);
         await _transactionRepository.SaveAsync(cancellationToken);
 
 
-        await _mediator.Send(new AddAttachmentsCommand(transaction.Id, request.AttachmentFiles), cancellationToken);
+        await _mediator.Send(new AddAttachmentsCommand(transaction.Id, request.NewAttachmentFiles), cancellationToken);
 
         return transaction.Id;
     }

--- a/Commands/Handlers/Transaction/EditTransaction/EditTransactionHandler.cs
+++ b/Commands/Handlers/Transaction/EditTransaction/EditTransactionHandler.cs
@@ -16,11 +16,11 @@ public class EditTransactionHandler : IRequestHandler<EditTransactionCommand, Gu
         _mapper = mapper;
         _mediator = mediator;
     }
+
     public async Task<Guid> Handle(EditTransactionCommand request, CancellationToken cancellationToken)
     {
         var transaction = await _transactionRepository.GetByIdAsync(request.Id, cancellationToken)
             ?? throw new ArgumentException($"No transaction found for Id {request.Id}", nameof(request.Id));
-
 
         var totalAmount = request.TransactionTypeAmounts.Sum(x => x.Amount);
 
@@ -30,11 +30,9 @@ public class EditTransactionHandler : IRequestHandler<EditTransactionCommand, Gu
         transaction.ChangeAmount(totalAmount, request.TransactionTypeAmounts);
         transaction.ChangeDescription(request.Description);
 
-
         await _transactionRepository.SaveAsync(cancellationToken);
 
-        
-        await _mediator.Send(new AddAttachmentsCommand(transaction.Id, request.AttachmentFiles), cancellationToken);
+        await _mediator.Send(new AddAttachmentsCommand(transaction.Id, request.NewAttachmentFiles), cancellationToken);
 
         return transaction.Id;
     }

--- a/Commands/Handlers/Transaction/EditTransaction/EditTransationCommand.cs
+++ b/Commands/Handlers/Transaction/EditTransaction/EditTransationCommand.cs
@@ -14,7 +14,7 @@ public record EditTransactionCommand(
     DateTimeOffset ReceivedDateTime,
     string Description,
     ICollection<TransactionTypeAmount> TransactionTypeAmounts,
-    ICollection<AttachmentFile> AttachmentFiles) : IRequest<Guid>;
+    ICollection<AttachmentFile> NewAttachmentFiles) : IRequest<Guid>;
 
 
 public class EditTransactionCommandValidator : AbstractValidator<EditTransactionCommand>
@@ -48,7 +48,7 @@ public class EditTransactionCommandValidator : AbstractValidator<EditTransaction
         RuleForEach(x => x.TransactionTypeAmounts)
             .SetValidator(new TransactionTypeValidator());
 
-        RuleForEach(x => x.AttachmentFiles)
+        RuleForEach(x => x.NewAttachmentFiles)
             .SetValidator(new AttachmentValidator());
 
     }

--- a/Web/MapperProfiles/MemberProfile.cs
+++ b/Web/MapperProfiles/MemberProfile.cs
@@ -19,7 +19,6 @@ public class MemberProfile : Profile
            .ForCtorParam(nameof(AddMemberCommand.Address), o => o.MapFrom(src => src))
            .ForMember(m => m.Address, o => o.MapFrom(src => src));
 
-
         CreateMap<MemberForm, Address>();
 
         CreateMap<MemberDetail, MemberForm>()

--- a/Web/MapperProfiles/TransactionProfile.cs
+++ b/Web/MapperProfiles/TransactionProfile.cs
@@ -1,21 +1,14 @@
 using AutoMapper;
 
-using Commands.Handlers;
 using Commands.Handlers.Transaction.AddCreditTransaction;
 using Commands.Handlers.Transaction.AddDebitTransaction;
-using Commands.Handlers.Transaction.EditTransaction;
-
-using Domain;
 
 using Queries.Members.Handlers.AutocompleteMember;
 using Queries.Transactions.ViewModels;
 
-using Types;
-
 using Web.Models;
 
 using AttachmentFile = Commands.Handlers.AttachmentFile;
-using TransactionAttachment = Domain.TransactionAttachment;
 using TransactionTypeAmount = Domain.TransactionTypeAmount;
 
 
@@ -30,17 +23,17 @@ public class TransactionProfile : Profile
             .ForMember(x => x.CounterPartyName, o => o.MapFrom(a => a.Counterparty.Name))
             .ForCtorParam(nameof(AddDebitTransactionCommand.MemberId), o => o.MapFrom(x => x.Counterparty.MemberId))
             .ForMember(x => x.MemberId, o => o.MapFrom(x => x.Counterparty.MemberId))
-            .ForCtorParam(nameof(AddCreditTransactionCommand.AttachmentFiles), o => o.MapFrom(x => x.TransactionAttachments))
-            .ForMember(x => x.AttachmentFiles, o => o.MapFrom(x => x.TransactionAttachments))
-            .ForCtorParam(nameof(AddCreditTransactionCommand.TransactionTypeAmounts), o => o.MapFrom(x => x.TransactionTypeAmounts));
+            .ForCtorParam(nameof(AddDebitTransactionCommand.NewAttachmentFiles), o => o.MapFrom(x => x.NewTransactionAttachments))
+            .ForMember(x => x.NewAttachmentFiles, o => o.MapFrom(x => x.NewTransactionAttachments))
+            .ForCtorParam(nameof(AddDebitTransactionCommand.TransactionTypeAmounts), o => o.MapFrom(x => x.TransactionTypeAmounts));
 
         CreateMap<TransactionForm, AddCreditTransactionCommand>()
             .ForCtorParam(nameof(AddCreditTransactionCommand.CounterPartyName), o => o.MapFrom(x => x.Counterparty.Name))
             .ForMember(x => x.CounterPartyName, o => o.MapFrom(x => x.Counterparty.Name))
             .ForCtorParam(nameof(AddCreditTransactionCommand.MemberId), o => o.MapFrom(x => x.Counterparty.MemberId))
             .ForMember(x => x.MemberId, o => o.MapFrom(x => x.Counterparty.MemberId))
-            .ForCtorParam(nameof(AddCreditTransactionCommand.AttachmentFiles), o => o.MapFrom(x => x.TransactionAttachments))
-            .ForMember(x => x.AttachmentFiles, o => o.MapFrom(x => x.TransactionAttachments))
+            .ForCtorParam(nameof(AddCreditTransactionCommand.NewAttachmentFiles), o => o.MapFrom(x => x.NewTransactionAttachments))
+            .ForMember(x => x.NewAttachmentFiles, o => o.MapFrom(x => x.NewTransactionAttachments))
             .ForCtorParam(nameof(AddCreditTransactionCommand.TransactionTypeAmounts), o => o.MapFrom(x => x.TransactionTypeAmounts));
 
         CreateMap<TransactionTypeAmountForm, TransactionTypeAmount>();
@@ -55,11 +48,12 @@ public class TransactionProfile : Profile
                 o => o.MapFrom(x => new AutocompleteCounterparty(x.CounterPartyName, x.MemberId)))
             .ForMember(x => x.TransactionAttachments, o => o.MapFrom(x => x.TransactionAttachments))
             .ForMember(x => x.NewMembershipExpirationDate, o => o.Ignore())
-            .ForMember(x => x.ApplyMembershipCalculation, o => o.Ignore());
+            .ForMember(x => x.ApplyMembershipCalculation, o => o.Ignore())
+            .ForMember(x => x.NewTransactionAttachments, o => o.Ignore());
 
         CreateMap<TransactionTypeAmount, TransactionTypeAmountForm>();
-        
-        CreateMap<Models.TransactionAttachment, AttachmentFile>()
+
+        CreateMap<NewTransactionAttachment, AttachmentFile>()
             .ForCtorParam(nameof(AttachmentFile.FileName), o => o.MapFrom(x => x.FileName))
             .ForMember(x => x.FileName, o => o.MapFrom(x => x.FileName))
             .ForCtorParam(nameof(AttachmentFile.UnsafePath), o => o.MapFrom(x => x.UnsafePath))
@@ -69,21 +63,14 @@ public class TransactionProfile : Profile
 
         CreateMap<Domain.TransactionAttachment, Queries.Transactions.ViewModels.TransactionAttachment>();
 
-        CreateMap<Queries.Transactions.ViewModels.TransactionAttachment, Web.Models.TransactionAttachment>()
+        CreateMap<Queries.Transactions.ViewModels.TransactionAttachment, Models.TransactionAttachment>()
             .ForCtorParam(nameof(Models.TransactionAttachment.FileName), o => o.MapFrom(x => x.Name))
-            .ForCtorParam(nameof(Models.TransactionAttachment.ContentType), o => o.MapFrom(x => string.Empty))
-            .ForCtorParam(nameof(Models.TransactionAttachment.UnsafePath), o => o.MapFrom(x => string.Empty))
-            .ForMember(x => x.FileName, o => o.MapFrom(x => x.Name))
-            .ForMember(x => x.ContentType, o => o.Ignore())
-            .ForMember(x => x.UnsafePath, o => o.Ignore());
+            .ForMember(x => x.FileName, o => o.MapFrom(x => x.Name));
 
         CreateMap<Queries.Transactions.ViewModels.TransactionTypeAmount, TransactionTypeAmountForm>()
             .ForCtorParam(nameof(TransactionTypeAmountForm.Amount), o => o.MapFrom(x => x.Amount))
             .ForCtorParam(nameof(TransactionTypeAmountForm.TransactionType), o => o.MapFrom(x => x.TransactionType))
             .ForMember(x => x.Amount, o => o.MapFrom(x => x.Amount))
             .ForMember(x => x.TransactionType, o => o.MapFrom(x => x.TransactionType));
-
-
-
     }
 }

--- a/Web/Models/TransactionForm.cs
+++ b/Web/Models/TransactionForm.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 using Queries.Members.Handlers.AutocompleteMember;
 
@@ -17,6 +16,7 @@ public class TransactionForm
             new(TransactionType.DebitMemberFee, null)
         };
         TransactionAttachments = new List<TransactionAttachment>();
+        NewTransactionAttachments = new List<NewTransactionAttachment>();
     }
 
     public Guid Id { get; set; }
@@ -36,8 +36,8 @@ public class TransactionForm
     [ValidateComplexType]
     public ICollection<TransactionTypeAmountForm> TransactionTypeAmounts { get; set; }
 
-
     public ICollection<TransactionAttachment> TransactionAttachments { get; set; }
+    public ICollection<NewTransactionAttachment> NewTransactionAttachments { get; set; }
     public DateTime? NewMembershipExpirationDate { get; set; }
     public bool ApplyMembershipCalculation { get; set; }
 }
@@ -60,7 +60,17 @@ public class TransactionTypeAmountForm
 
 public class TransactionAttachment
 {
-    public TransactionAttachment(string fileName, string contentType, string unsafePath)
+    public TransactionAttachment(string fileName)
+    {
+        FileName = fileName;
+    }
+    public string FileName { get; set; }
+}
+
+
+public class NewTransactionAttachment
+{
+    public NewTransactionAttachment(string fileName, string contentType, string unsafePath)
     {
         FileName = fileName;
         ContentType = contentType;

--- a/Web/Pages/Transactions/EditTransaction.razor
+++ b/Web/Pages/Transactions/EditTransaction.razor
@@ -66,10 +66,10 @@
             TransactionTypeAmounts: Transaction.TransactionTypeAmounts
                 .Select(x => new TransactionTypeAmount(x.TransactionType!.Value, x.Amount!.Value))
                 .ToList(),
-            AttachmentFiles: Transaction.TransactionAttachments
+            NewAttachmentFiles: Transaction.NewTransactionAttachments
                 .Select(x => new AttachmentFile(x.FileName, x.ContentType, x.UnsafePath))
-                .ToList()
-                );
+                .ToList());
+                
         var response = await Mediator.Send(command);
         if (memberId.HasValue && expirationDate.HasValue && applyCalculation)
         {

--- a/Web/Pages/Transactions/TransactionForm.razor
+++ b/Web/Pages/Transactions/TransactionForm.razor
@@ -201,7 +201,6 @@
             <MudCheckBox Color="Color.Secondary" @bind-Checked="Transaction.ApplyMembershipCalculation">Extend membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths more month(s) of membership</MudCheckBox>
 
             <MudGrid>
-
                 <MudDatePicker Label="New expiration month"
                                @bind-Date="Transaction.NewMembershipExpirationDate"
                                DisableToolbar="true"
@@ -217,12 +216,18 @@
         <MudListSubheader>
             Attachments
         </MudListSubheader>
+        @foreach (var attachment in Transaction.NewTransactionAttachments)
+        {
+            <MudListItem Icon="@Icons.Material.Outlined.SaveAs"
+                         OnClick="() => Download(attachment.FileName)">
+                @attachment.FileName
+            </MudListItem>
+        }
         @foreach (var attachment in Transaction.TransactionAttachments)
         {
             <MudListItem Icon="@Icons.Material.Outlined.Save"
                          OnClick="() => Download(attachment.FileName)">
                 @attachment.FileName
-
             </MudListItem>
         }
     </MudList>
@@ -360,9 +365,9 @@
             return;
         }
         var existingFileNames = Transaction.TransactionAttachments.Select(x => x.FileName).ToList();
-        var duplicateEntries = entries.Where(x => existingFileNames.All(fileName => fileName != x.Name));
+        var newFiles = entries.Where(x => existingFileNames.All(fileName => fileName != x.Name));
 
-        foreach (var file in duplicateEntries)
+        foreach (var file in newFiles)
         {
             var trustedFileNameForFileStorage = Path.GetRandomFileName();
             var directory = Path.Combine(Environment.ContentRootPath,
@@ -372,8 +377,8 @@
 
             await using FileStream fs = new(path, FileMode.Create);
             await file.OpenReadStream(_maxAllowedSize).CopyToAsync(fs);
-            var transaction = new TransactionAttachment(file.Name, file.ContentType, path);
-            Transaction.TransactionAttachments.Add(transaction);
+            var transaction = new NewTransactionAttachment(file.Name, file.ContentType, path);
+            Transaction.NewTransactionAttachments.Add(transaction);
         }
     }
 

--- a/Web/appsettings.Development.json
+++ b/Web/appsettings.Development.json
@@ -13,5 +13,9 @@
   "Oidc": {
     "Audience": "haspman",
     "Authority": "http://localhost:5202/auth/realms/DevRealm"
+  },
+  "Storage": {
+    "ConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;",
+    "StorageContainerName": "haspman-dev-local"
   }
 }

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -6,9 +6,5 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*",
-  "Storage": {
-    "ConnectionString": "",
-    "StorageContainerName": ""
-  }
+  "AllowedHosts": "*"
 }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -29,3 +29,12 @@ services:
       - 5202:8080
     volumes:
       - ./Infrastructure/Keycloak/DevRealm.json:/tmp/DevRealm.json
+ 
+  azurerite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    ports:
+      - 10000:10000
+      - 10001:10001
+      - 10002:10002
+    volumes:
+      - ./.dev/azurite:/data


### PR DESCRIPTION
fix: Split handling of new and existing attachments

New attachments are now treated separately, with an edit (saveAs) icon displayed next to them when editing a transation.
This was necessary because we didn't store some data (contentType and unsafePath) for existing attachments (and which we didn't need to store), but since existing attachments were treated as new attachments, this would fail when mapping the items.

Fixes #160 