### PR TITLE
fix: Use dedicated record for bank account with totals #177

### DIFF
--- a/Queries/BankAccounts/BankAccountDetail.cs
+++ b/Queries/BankAccounts/BankAccountDetail.cs
@@ -1,3 +1,5 @@
 namespace Queries.BankAccounts;
 
-public record BankAccountDetail(Guid Id, string Name, string AccountNumber, decimal TotalAmount, long NumberOfTransactions);
+
+public record BankAccountDetail(Guid Id, string Name, string AccountNumber);
+public record BankAccountDetailWithTotal(Guid Id, string Name, string AccountNumber, decimal TotalAmount, long NumberOfTransactions);

--- a/Web/MapperProfiles/BankAccountProfile.cs
+++ b/Web/MapperProfiles/BankAccountProfile.cs
@@ -2,6 +2,8 @@ using AutoMapper;
 
 using Commands.Handlers.BankAccount.AddBankAccount;
 
+using Domain;
+
 using Persistence.Views;
 
 using Queries.BankAccounts;
@@ -19,10 +21,14 @@ public class BankAccountProfile : Profile
             .ForCtorParam(nameof(AddBankAccountCommand.AccountNumber), o => o.MapFrom(src => src.AccountNumber));
 
         CreateMap<BankAccountDetail, BankAccountForm>();
-        CreateMap<BankAccountsWithTotals, BankAccountDetail>()
-            .ForCtorParam(nameof(BankAccountDetail.AccountNumber), o => o.MapFrom(src => src.Account.AccountNumber))
-            .ForCtorParam(nameof(BankAccountDetail.Id), o => o.MapFrom(src => src.BankAccountId))
-            .ForCtorParam(nameof(BankAccountDetail.Name), o => o.MapFrom(src => src.Account.Name))
-            .ForCtorParam(nameof(BankAccountDetail.TotalAmount), o => o.MapFrom(src => src.Total));
+        CreateMap<BankAccount, BankAccountDetail>()
+            .ForCtorParam(nameof(BankAccountDetail.Id), o => o.MapFrom(src => src.Id))
+            .ForCtorParam(nameof(BankAccountDetail.AccountNumber), o => o.MapFrom(src => src.AccountNumber))
+            .ForCtorParam(nameof(BankAccountDetail.Name), o => o.MapFrom(src => src.Name));
+        CreateMap<BankAccountsWithTotals, BankAccountDetailWithTotal>()
+            .ForCtorParam(nameof(BankAccountDetailWithTotal.AccountNumber), o => o.MapFrom(src => src.Account.AccountNumber))
+            .ForCtorParam(nameof(BankAccountDetailWithTotal.Id), o => o.MapFrom(src => src.BankAccountId))
+            .ForCtorParam(nameof(BankAccountDetailWithTotal.Name), o => o.MapFrom(src => src.Account.Name))
+            .ForCtorParam(nameof(BankAccountDetailWithTotal.TotalAmount), o => o.MapFrom(src => src.Total));
     }
 }

--- a/Web/Pages/BankAccounts/BankAccounts.razor
+++ b/Web/Pages/BankAccounts/BankAccounts.razor
@@ -9,7 +9,7 @@
           Dense="true"
           Hover="true"
           @ref="table"
-          ServerData="@(new Func<TableState, Task<TableData<BankAccountDetail>>>(ServerReload))">
+          ServerData="@(new Func<TableState, Task<TableData<BankAccountDetailWithTotal>>>(ServerReload))">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Bankaccounts</MudText>
         <MudSpacer />
@@ -85,10 +85,10 @@
 </MudTable>
 
 @code {
-    private MudTable<BankAccountDetail>? table;
+    private MudTable<BankAccountDetailWithTotal>? table;
     private string searchString = "";
 
-    private async Task<TableData<BankAccountDetail>> ServerReload(TableState state)
+    private async Task<TableData<BankAccountDetailWithTotal>> ServerReload(TableState state)
     {
         StateHasChanged();
 
@@ -102,7 +102,7 @@
         var query = new SearchBankAccountsQuery(searchString, state.Page, state.PageSize, orderBy, sortDirection);
         var data = await _mediator.Send(query);
 
-        return new TableData<BankAccountDetail>()
+        return new TableData<BankAccountDetailWithTotal>()
         {
             TotalItems = data.Total,
             Items = data.Items


### PR DESCRIPTION
When editing a bank account, the page would crash.
I fixed it by adding a dedicated record for the bank account with totals.

Since there was no requirement to show the totals on the edit page, this seems to me to be the best fix.