### PR TITLE
feat: Member mailing

### DIFF
--- a/Commands/Configuration/MailingConfiguration.cs
+++ b/Commands/Configuration/MailingConfiguration.cs
@@ -25,6 +25,8 @@ public class MailingConfiguration
         public string? Password { get; set; }
 
         public bool RequiresAuthentication => !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrWhiteSpace(Password);
+
+        public bool EnableSsl { get; set; } = false;
     }
 
     public class SenderConfiguration

--- a/Commands/Configuration/MailingConfiguration.cs
+++ b/Commands/Configuration/MailingConfiguration.cs
@@ -24,7 +24,7 @@ public class MailingConfiguration
 
         public string? Password { get; set; }
 
-        public bool RequiresAuthentication => !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrWhiteSpace(Password);
+        public bool HaveCredentials => !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrWhiteSpace(Password);
 
         public bool EnableSsl { get; set; } = false;
     }

--- a/Commands/Configuration/MailingConfiguration.cs
+++ b/Commands/Configuration/MailingConfiguration.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Commands.Configuration;
+public class MailingConfiguration
+{
+    public const string SectionName = "Mailing";
+
+    [Required]
+    public MailServerConfiguration MailServer { get; set; } = default!;
+
+    [Required]
+    public SenderConfiguration Sender { get; set; } = default!;
+
+    public class MailServerConfiguration
+    {
+        [Required(AllowEmptyStrings = false)]
+        public string Host { get; set; } = default!;
+
+        [Range(1, 63535)]
+
+        public int Port { get; set; }
+
+        public string? Username { get; set; }
+
+        public string? Password { get; set; }
+
+        public bool RequiresAuthentication => !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrWhiteSpace(Password);
+    }
+
+    public class SenderConfiguration
+    {
+        [Required(AllowEmptyStrings = false)]
+        public string Email { get; set; } = default!;
+
+        [Required(AllowEmptyStrings = false)]
+        public string Name { get; set; } = default!;
+    }
+}

--- a/Commands/Handlers/Member/EmailMember/EmailMembersCommand.cs
+++ b/Commands/Handlers/Member/EmailMember/EmailMembersCommand.cs
@@ -1,0 +1,4 @@
+﻿using Commands.Services;
+
+namespace Commands.Handlers.Member.EmailMember;
+public record EmailMembersCommand(IEnumerable<Guid> MemberIds, string Subject, string Message) : IRequest<IEnumerable<SendError>>;

--- a/Commands/Handlers/Member/EmailMember/EmailMembersHandler.cs
+++ b/Commands/Handlers/Member/EmailMember/EmailMembersHandler.cs
@@ -1,0 +1,30 @@
+﻿using Commands.Services;
+
+using Microsoft.EntityFrameworkCore;
+
+using Persistence;
+
+namespace Commands.Handlers.Member.EmailMember;
+internal class EmailMembersHandler : IRequestHandler<EmailMembersCommand, IEnumerable<SendError>>
+{
+    private readonly IMailingService _mailingService;
+    private readonly HaSpManContext _dbContext;
+
+    public EmailMembersHandler(IMailingService mailingService, HaSpManContext dbContext)
+    {
+        _mailingService = mailingService ?? throw new ArgumentNullException(nameof(mailingService));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<IEnumerable<SendError>> Handle(EmailMembersCommand request, CancellationToken cancellationToken)
+    {
+        var members = await _dbContext.Members
+            .AsNoTracking()
+            .Where(m => request.MemberIds.Contains(m.Id) && !string.IsNullOrWhiteSpace(m.Email))
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        var errors = await _mailingService.SendMailAsync(members, new(request.Subject, request.Message), cancellationToken);
+
+        return errors;
+    }
+}

--- a/Commands/Services/MailingService.cs
+++ b/Commands/Services/MailingService.cs
@@ -1,0 +1,68 @@
+﻿using System.Net.Mail;
+
+using Commands.Configuration;
+
+using Domain;
+
+using Microsoft.Extensions.Options;
+
+namespace Commands.Services;
+
+public interface IMailingService
+{
+    Task<IEnumerable<SendError>> SendMailAsync(IEnumerable<Member> members, Message message, CancellationToken ct);
+}
+
+public class MailingService : IMailingService
+{
+    private readonly MailingConfiguration _config;
+    public MailingService(IOptions<MailingConfiguration> options)
+    {
+        if (options is null)
+            throw new ArgumentNullException(nameof(options));
+
+        _config = options.Value;
+    }
+
+    public async Task<IEnumerable<SendError>> SendMailAsync(IEnumerable<Member> members, Message message, CancellationToken ct)
+    {
+        var sender = new MailAddress(_config.Sender.Email, _config.Sender.Name);
+        var recipients = members.Select(m => new MailAddress(m.Email ?? throw new Exception("Can't send email to members without email address"), m.Name));
+
+        var messages = recipients.Select(r => new MailMessage(sender, r)
+        {
+            Subject = message.Subject,
+            Body = message.Body
+
+        });
+
+        var errors = new List<SendError>();
+
+        var mailTasks = messages.Select(async msg =>
+        {
+            try
+            {
+                using var client = GetSmtpClient;
+                await client.SendMailAsync(msg, ct);
+            }
+            catch (SmtpException ex)
+            {
+                errors.Add(new(msg.To.Single().Address, ex.Message));
+            }
+        });
+
+        await Task.WhenAll(mailTasks);
+
+        return errors;
+    }
+
+    private SmtpClient GetSmtpClient => new SmtpClient(_config.MailServer.Host, _config.MailServer.Port)
+    {
+        TargetName = _config.MailServer.Host == "smtp.office365.com"
+            ? "STARTTLS/smtp.office365.com"
+            : null
+    };
+}
+
+public record Message(string Subject, string Body);
+public record SendError(string Email, string Error);

--- a/Commands/Services/MailingService.cs
+++ b/Commands/Services/MailingService.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Mail;
+﻿using System.Net;
+using System.Net.Mail;
 
 using Commands.Configuration;
 
@@ -58,8 +59,12 @@ public class MailingService : IMailingService
 
     private SmtpClient GetSmtpClient => new SmtpClient(_config.MailServer.Host, _config.MailServer.Port)
     {
+        EnableSsl = _config.MailServer.EnableSsl,
         TargetName = _config.MailServer.Host == "smtp.office365.com"
             ? "STARTTLS/smtp.office365.com"
+            : null,
+        Credentials = _config.MailServer.RequiresAuthentication
+            ? new NetworkCredential(_config.MailServer.Username, _config.MailServer.Password)
             : null
     };
 }

--- a/Commands/Services/MailingService.cs
+++ b/Commands/Services/MailingService.cs
@@ -63,7 +63,7 @@ public class MailingService : IMailingService
         TargetName = _config.MailServer.Host == "smtp.office365.com"
             ? "STARTTLS/smtp.office365.com"
             : null,
-        Credentials = _config.MailServer.RequiresAuthentication
+        Credentials = _config.MailServer.HaveCredentials
             ? new NetworkCredential(_config.MailServer.Username, _config.MailServer.Password)
             : null
     };

--- a/HaSpMan.sln
+++ b/HaSpMan.sln
@@ -24,6 +24,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FF2A0D78-2030-4F77-9284-88A9F85327CA}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		docker-compose.dev.yaml = docker-compose.dev.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain.Test", "Domain.Test\Domain.Test.csproj", "{AFD477E3-A4CB-474C-B2F1-340B8FEBD0C9}"

--- a/Infrastructure/helm-charts/haspman/templates/deployment.yaml
+++ b/Infrastructure/helm-charts/haspman/templates/deployment.yaml
@@ -53,6 +53,30 @@ spec:
                 secretKeyRef:
                   name: {{ include "haspman.fullname" . }}
                   key: CLIENT_SECRET
+            - name: Mailing__MailServer__Host
+              value: {{ required "A valid .Values.haspman.mailing.mailServer.host entry is required" .Values.haspman.mailing.mailServer.host | quote}}
+            {{- if .Values.haspman.mailing.mailServer.port }}
+            - name: Mailing__MailServer__Port
+              value: {{ .Values.haspman.mailing.mailServer.port }}
+            {{- end }}
+            - name: Mailing__MailServer__EnableSsl
+              value: {{ .Values.haspman.mailing.mailServer.enableSsl }}
+            - name: Mailing__Sender__Email
+              value: {{ required "A valid .Values.haspman.mailing.sender.email entry is required" .Values.haspman.mailing.sender.email | quote}}
+            - name: Mailing__Sender__Name
+              value: {{ required "A valid .Values.haspman.mailing.sender.name entry is required" .Values.haspman.mailing.sender.name | quote}}
+            {{- if or (.Values.haspman.mailing.mailServer.username) (.Values.haspman.mailing.mailServer.password) }}
+            - name: Mailing__MailServer__Username
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "haspman.fullname" . }}
+                  key: MAILSERVER_USERNAME
+            - name: Mailing__MailServer__Password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "haspman.fullname" . }}
+                  key: MAILSERVER_PASSWORD
+            {{- end}}
           ports:
             - name: http
               containerPort: 80

--- a/Infrastructure/helm-charts/haspman/templates/secret.yaml
+++ b/Infrastructure/helm-charts/haspman/templates/secret.yaml
@@ -9,3 +9,7 @@ data:
   CLIENT_SECRET: {{ required "A valid .Values.haspman.oauth.clientSecret entry required!" .Values.haspman.oauth.clientSecret | b64enc | quote }}
   DB_CONNECTION_STRING: {{ required "A valid .Values.haspman.dbConnectionString entry required!" .Values.haspman.dbConnectionString | b64enc | quote }}
   STORAGE_CONNECTION_STRING: {{ required "A valid .Values.haspman.storageConnectionString entry required!" .Values.haspman.storageConnectionString | b64enc | quote }}
+  {{- if or (.Values.haspman.mailing.mailServer.username) (.Values.haspman.mailing.mailServer.password) }}
+  MAILSERVER_USERNAME: {{ required "A valid .Values.haspman.mailing.mailServer.username entry is required" .Values.haspman.mailing.mailServer.username }}
+  MAILSERVER_PASSWORD: {{ required "A valid .Values.haspman.mailing.mailServer.password entry is required" .Values.haspman.mailing.mailServer.password }}
+  {{- end}}

--- a/Infrastructure/helm-charts/haspman/values.yaml
+++ b/Infrastructure/helm-charts/haspman/values.yaml
@@ -22,10 +22,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -78,3 +80,13 @@ haspman:
     clientId: ""
     clientSecret: ""
     authority: ""
+  mailing:
+    mailServer:
+      host: ""
+      port: ""
+      username: ""
+      password: ""
+      enableSsl: false
+    sender:
+      email: ""
+      name: ""

--- a/Web/Extensions/MailingExtensions.cs
+++ b/Web/Extensions/MailingExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Commands.Configuration;
+using Commands.Services;
+
+namespace Web.Extensions;
+
+public static class MailingExtensions
+{
+    public static IServiceCollection AddMailingService(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<MailingConfiguration>()
+            .Bind(configuration.GetSection(MailingConfiguration.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddSingleton<IMailingService, MailingService>();
+
+        return services;
+    }
+}

--- a/Web/Pages/Members/EmailMembersDialog.razor
+++ b/Web/Pages/Members/EmailMembersDialog.razor
@@ -1,0 +1,50 @@
+﻿@using Commands.Services;
+@using System.ComponentModel.DataAnnotations;
+<EditForm Model="@_messageForm" OnValidSubmit="@Submit">
+    <MudDialog>
+        <DialogContent>
+            <MudText>Note: Members without email addresses will be excluded from the mailing</MudText>
+            <DataAnnotationsValidator />
+            <MudTextField @bind-Value="_messageForm.Subject"
+                          For="@(() => _messageForm.Subject)"
+                          Label="Subject"
+                          T="string"
+                          Required="true" />
+            <MudTextField @bind-Value="_messageForm.Message"
+                          For="@(() => _messageForm.Message)"
+                          Label="Message"
+                          T="string"
+                          Required="true"
+                          Lines="10" />
+        </DialogContent>
+        <DialogActions>
+            <MudButton OnClick="Cancel">Cancel</MudButton>
+            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary">Ok</MudButton>
+        </DialogActions>
+    </MudDialog>
+
+</EditForm> 
+
+@code {
+    private MessageForm _messageForm = new();
+
+    [CascadingParameter]
+    MudDialogInstance? MudDialog { get; set; }
+
+    void Submit()
+    {
+
+        MudDialog?.Close(DialogResult.Ok(new Message(_messageForm.Subject, _messageForm.Message)));
+    }
+
+    void Cancel() => MudDialog?.Cancel();
+
+    public class MessageForm
+    {
+        [Required(AllowEmptyStrings = false)]
+        public string Subject { get; set; } = default!;
+
+        [Required(AllowEmptyStrings = false)]
+        public string Message { get; set; } = default!;
+    }
+}

--- a/Web/Pages/Members/Members.razor
+++ b/Web/Pages/Members/Members.razor
@@ -1,6 +1,8 @@
 ﻿@page "/members"
 @attribute [Authorize]
 
+@using Commands.Handlers.Member.EmailMember;
+@using Commands.Services;
 @using MediatR
 @using Queries.Members.Handlers.SearchMembers
 @using Queries.Members.ViewModels
@@ -10,7 +12,8 @@
 @inject ISnackbar Snackbar
 
 <MudTable Class="mt-10 mw-13" Dense="true" Hover="true" @ref="_table"
-    ServerData="@(new Func<TableState, Task<TableData<MemberSummary>>>(ServerReload))">
+    ServerData="@(new Func<TableState, Task<TableData<MemberSummary>>>(ServerReload))" MultiSelection="true"
+    @bind-SelectedItems="_selectedMembers">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Members</MudText>
         <MudSpacer />
@@ -20,6 +23,10 @@
         <MudSwitch @bind-Checked="@ShowActive" Label="Active" Color="Color.Success" T="bool" />
         <MudSwitch @bind-Checked="@ShowInactive" Label="Inactive" Color="Color.Error" T="bool" />
         <MudSpacer />
+        <MudButton Class="ma-2" DisableElevation="true" Size="Size.Small" Variant="Variant.Outlined"
+            Disabled="@(!_selectedMembers.Any())" @onclick="OpenSendEmailDialog">
+            Email selected members
+        </MudButton>
         <MudButton Class="ma-2" Color="Color.Primary" DisableElevation="true" Href="/members/new" Size="Size.Small"
             Variant="Variant.Filled">
             Add member
@@ -134,6 +141,8 @@
         }
     }
 
+    private HashSet<MemberSummary> _selectedMembers = new();
+
     private async Task<TableData<MemberSummary>> ServerReload(TableState state)
     {
         StateHasChanged();
@@ -185,4 +194,20 @@
 
     private string GetExpiryDate(MemberSummary member) => member.MembershipExpiryDate?.Date.ToString("dd/MM/yyyy")
     ?? "Never";
+
+    private async Task OpenSendEmailDialog()
+    {
+        var dialog = DialogService.Show<EmailMembersDialog>($"Email {_selectedMembers.Count} selected members");
+        var result = await dialog.Result;
+        if (!result.Canceled && result.Data is Message)
+        {
+            var message = (Message)result.Data;
+            var command = new EmailMembersCommand(_selectedMembers.Select(m => m.Id), message.Subject, message.Body);
+            var errors = await _mediator.Send(command);
+            foreach (var error in errors)
+                Snackbar.Add($"Failed to send email to {error.Email} because: {error.Error}", Severity.Error);
+
+            _selectedMembers = new();
+        }
+    }
 }

--- a/Web/Pages/Members/Members.razor
+++ b/Web/Pages/Members/Members.razor
@@ -202,10 +202,17 @@
         if (!result.Canceled && result.Data is Message)
         {
             var message = (Message)result.Data;
-            var command = new EmailMembersCommand(_selectedMembers.Select(m => m.Id), message.Subject, message.Body);
+            var memberIds = _selectedMembers
+                .Where(m => !string.IsNullOrWhiteSpace(m.Email))
+                .Select(m => m.Id);
+            var command = new EmailMembersCommand(memberIds, message.Subject, message.Body);
             var errors = await _mediator.Send(command);
             foreach (var error in errors)
                 Snackbar.Add($"Failed to send email to {error.Email} because: {error.Error}", Severity.Error);
+
+            var successfulEmails = command.MemberIds.Count() - errors.Count();
+            if (successfulEmails > 0)
+                Snackbar.Add($"Successfully sent email to {successfulEmails} members");
 
             _selectedMembers = new();
         }

--- a/Web/Pages/_Host.cshtml
+++ b/Web/Pages/_Host.cshtml
@@ -2,57 +2,56 @@
 @namespace Web.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
-   Layout = null;
+    Layout = null;
 }
 
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
-   <meta charset="utf-8" />
-   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-   <title>HaSpMan</title>
-   <base href="~/" />
-   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-   <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-   <link href="css/site.css" rel="stylesheet" />
-   <link href="Web.styles.css" rel="stylesheet">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HaSpMan</title>
+    <base href="~/" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="css/site.css" rel="stylesheet" />
+    <link href="Web.styles.css" rel="stylesheet">
 </head>
 
 <body>
-   <script src="_content/MudBlazor/MudBlazor.min.js"></script>
-   <component type="typeof(App)" render-mode="ServerPrerendered" />
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
 
-   <div id="blazor-error-ui">
-      <environment include="Staging,Production">
-         An error has occurred. This application may no longer respond until reloaded.
-      </environment>
-      <environment include="Development">
-         An unhandled exception has occurred. See browser dev tools for details.
-      </environment>
-      <a href="" class="reload">Reload</a>
-      <a class="dismiss">🗙</a>
-   </div>
+    <div id="blazor-error-ui">
+        <environment include="Staging,Production">
+            An error has occurred. This application may no longer respond until reloaded.
+        </environment>
+        <environment include="Development">
+            An unhandled exception has occurred. See browser dev tools for details.
+        </environment>
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
 
-   <script src="_framework/blazor.server.js"></script>
-   <script>
-      
-         winow.triggerFileDownload = (fileName, url) => {
+    <script src="_framework/blazor.server.js"></script>
+    <script>
+        winow.triggerFileDownload = (fileName, url) => {
             const anchorElement = document.createElement('a');
-         anchorElement.href = url;
-         anchorElement.download = fileName ?? '';
-         anchorElement.click();
-          anchorElement.remove();
-     }
-         winow.downloadFileFromStream = async (fileName, contentStreamReference) => {
+            anchorElement.href = url;
+            anchorElement.download = fileName ?? '';
+            anchorElement.click();
+            anchorElement.remove();
+        }
+        winow.downloadFileFromStream = async (fileName, contentStreamReference) => {
             const arrayBuffer = await contentStreamReference.arrayBuffer();
-         const blob = new Blob([arrayBuffer]);
-         const url = URL.createObjectURL(blob);
-         triggerFileDownload(fileName, url);
-          URL.revokeObjectURL(url);
-       }
-    
+            const blob = new Blob([arrayBuffer]);
+            const url = URL.createObjectURL(blob);
+            triggerFileDownload(fileName, url);
+            URL.revokeObjectURL(url);
+        }
 
-</s      </body>
+    </script>
+</body>
 
 </html>

--- a/Web/Pages/_Host.cshtml
+++ b/Web/Pages/_Host.cshtml
@@ -34,23 +34,24 @@
       <a class="dismiss">🗙</a>
    </div>
 
-    <script src="_framework/blazor.server.js"></script>
-    <script>
-        window.triggerFileDownload = (fileName, url) => {
-            const anchorElement = document.createElement('a');
-            anchorElement.href = url;
-            anchorElement.download = fileName ?? '';
-            anchorElement.click();
-            anchorElement.remove();
+   <script src="_framework/blazor.server.js"></script>
+   <script src="_content/TinyMCE.Blazor/tinymce-blazor.js"></script>
+   <scipt>
+      winow.triggerFileDownload = (fileName, url) => {
+         const anchorElement = document.createElement('a');
+         anchorElement.href = url;
+         anchorElement.download = fileName ?? '';
+         anchorElement.click();
+          anchorElement.remove();
+      }
+      winow.downloadFileFromStream = async (fileName, contentStreamReference) => {
+         const arrayBuffer = await contentStreamReference.arrayBuffer();
+         const blob = new Blob([arrayBuffer]);
+         const url = URL.createObjectURL(blob);
+         triggerFileDownload(fileName, url);
+          URL.revokeObjectURL(url);
         }
-        window.downloadFileFromStream = async (fileName, contentStreamReference) => {
-            const arrayBuffer = await contentStreamReference.arrayBuffer();
-            const blob = new Blob([arrayBuffer]);
-            const url = URL.createObjectURL(blob);
-            triggerFileDownload(fileName, url);
-            URL.revokeObjectURL(url);
-        }
-
+   
 </script>
 </body>
 

--- a/Web/Pages/_Host.cshtml
+++ b/Web/Pages/_Host.cshtml
@@ -35,24 +35,24 @@
    </div>
 
    <script src="_framework/blazor.server.js"></script>
-   <script src="_content/TinyMCE.Blazor/tinymce-blazor.js"></script>
-   <scipt>
-      winow.triggerFileDownload = (fileName, url) => {
-         const anchorElement = document.createElement('a');
+   <script>
+      
+         winow.triggerFileDownload = (fileName, url) => {
+            const anchorElement = document.createElement('a');
          anchorElement.href = url;
          anchorElement.download = fileName ?? '';
          anchorElement.click();
           anchorElement.remove();
-      }
-      winow.downloadFileFromStream = async (fileName, contentStreamReference) => {
-         const arrayBuffer = await contentStreamReference.arrayBuffer();
+     }
+         winow.downloadFileFromStream = async (fileName, contentStreamReference) => {
+            const arrayBuffer = await contentStreamReference.arrayBuffer();
          const blob = new Blob([arrayBuffer]);
          const url = URL.createObjectURL(blob);
          triggerFileDownload(fileName, url);
           URL.revokeObjectURL(url);
-        }
-   
-</script>
-</body>
+       }
+    
+
+</s      </body>
 
 </html>

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -84,7 +84,7 @@ public class Startup
         });
         services.AddHttpContextAccessor();
         services.AddScoped<IUserAccessor, UserAccessor>();
-
+        services.AddMailingService(Configuration);
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Web/appsettings.Development.json
+++ b/Web/appsettings.Development.json
@@ -1,21 +1,31 @@
 {
-  "DetailedErrors": true,
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  },
-  "ConnectionStrings": {
-    "HaSpMan": "Server=localhost,5201;Database=HaSpMan;User Id=sa;Password=Dev-db-Password;TrustServerCertificate=Yes"
-  },
-  "Oidc": {
-    "Audience": "haspman",
-    "Authority": "http://localhost:5202/auth/realms/DevRealm"
-  },
-  "Storage": {
-    "ConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;",
-    "StorageContainerName": "haspman-dev-local"
-  }
+   "DetailedErrors": true,
+   "Logging": {
+      "LogLevel": {
+         "Default": "Information",
+         "Microsoft": "Warning",
+         "Microsoft.Hosting.Lifetime": "Information"
+      }
+   },
+   "ConnectionStrings": {
+      "HaSpMan": "Server=localhost,5201;Database=HaSpMan;User Id=sa;Password=Dev-db-Password;TrustServerCertificate=Yes"
+   },
+   "Oidc": {
+      "Audience": "haspman",
+      "Authority": "http://localhost:5202/auth/realms/DevRealm"
+   },
+   "Storage": {
+      "ConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;",
+      "StorageContainerName": "haspman-dev-local"
+   },
+   "Mailing": {
+      "MailServer": {
+         "Host": "localhost",
+         "Port": "5204"
+      },
+      "Sender": {
+         "Email": "noreply@example.com",
+         "Name": "Do not reply"
+      }
+   }
 }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -38,3 +38,9 @@ services:
       - 10002:10002
     volumes:
       - ./.dev/azurite:/data
+
+  smtp4dev:
+    image: rnwood/smtp4dev:v3
+    ports:
+      - '5203:80'
+      - '5204:25'


### PR DESCRIPTION
This PR adds SMTP mailing support to HaSpMan.
In the members overview, one or more members can be selected, which will enable this button in the top toolbar of the table:
![image](https://github.com/Brixel/HaSpMan/assets/3620147/320a608e-506a-40a0-88e7-041221c6b2b7)

This will open the send email dialog, in which a subject and message can be specified:
![image](https://github.com/Brixel/HaSpMan/assets/3620147/5bd7547d-e599-4059-a10a-8e0361f4d952)

After confiming this, the message with the specified subject and body will be sent to all users which were previously selected.

Note that HaSpMan at this point does not require an email address of members, if a valid phone number is specified.
Due to a limitation in MudBlazor (and the lack of enthousiasm of building an alternative myself), it is not possible to disable selecting members without email addresses when sending an email. We will however silently ignore these users when sending the email.

As this can be used in conjunction with the already existing filters for active/inactive members, this should resolve #95 