### PR TITLE
Fix/disable adding transactions to closed year

### DIFF
--- a/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionCommand.cs
+++ b/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionCommand.cs
@@ -14,7 +14,8 @@ public record AddCreditTransactionCommand(
     string Description,
     Guid? MemberId,
     ICollection<TransactionTypeAmount> TransactionTypeAmounts,
-    ICollection<AttachmentFile> NewAttachmentFiles) : IRequest<Guid>;
+    ICollection<AttachmentFile> NewAttachmentFiles,
+    Guid FinancialYearId) : IRequest<Guid>;
 
 public class AddCreditTransactionCommandValidator : AbstractValidator<AddCreditTransactionCommand>
 {
@@ -46,5 +47,8 @@ public class AddCreditTransactionCommandValidator : AbstractValidator<AddCreditT
 
         RuleForEach(x => x.NewAttachmentFiles)
             .SetValidator(new AttachmentValidator());
+
+        RuleFor(x => x.FinancialYearId)
+            .NotEmpty();
     }
 }

--- a/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionHandler.cs
+++ b/Commands/Handlers/Transaction/AddCreditTransaction/AddCreditTransactionHandler.cs
@@ -21,7 +21,7 @@ public class AddCreditTransactionHandler : IRequestHandler<AddCreditTransactionC
     {
 
         var financialYear =
-            await _financialYearRepository.GetFinancialYearByDateAsync(request.ReceivedDateTime, cancellationToken)
+            await _financialYearRepository.GetFinancialYearByTransactionId(request.FinancialYearId, cancellationToken)
             ?? await _mediator.Send(new AddFinancialYearCommand(), cancellationToken);
 
         var totalAmount = request.TransactionTypeAmounts.Sum(x => x.Amount);

--- a/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionCommand.cs
+++ b/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionCommand.cs
@@ -13,7 +13,8 @@ public record AddDebitTransactionCommand(
     string Description,
     Guid? MemberId,
     ICollection<TransactionTypeAmount> TransactionTypeAmounts,
-    ICollection<AttachmentFile> NewAttachmentFiles) : IRequest<Guid>;
+    ICollection<AttachmentFile> NewAttachmentFiles,
+    Guid FinancialYearId) : IRequest<Guid>;
 
 public class AddDebitTransactionCommandValidator : AbstractValidator<AddDebitTransactionCommand>
 {
@@ -45,5 +46,8 @@ public class AddDebitTransactionCommandValidator : AbstractValidator<AddDebitTra
 
         RuleForEach(x => x.NewAttachmentFiles)
             .SetValidator(new AttachmentValidator());
+
+        RuleFor(x => x.FinancialYearId)
+            .NotEmpty();
     }
 }

--- a/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionHandler.cs
+++ b/Commands/Handlers/Transaction/AddDebitTransaction/AddDebitTransactionHandler.cs
@@ -19,7 +19,7 @@ public class AddDebitTransactionHandler : IRequestHandler<AddDebitTransactionCom
     public async Task<Guid> Handle(AddDebitTransactionCommand request, CancellationToken cancellationToken)
     {
         var financialYear =
-            await _financialYearRepository.GetFinancialYearByDateAsync(request.ReceivedDateTime, cancellationToken)
+            await _financialYearRepository.GetFinancialYearByTransactionId(request.FinancialYearId, cancellationToken)
             ?? await _mediator.Send(new AddFinancialYearCommand(), cancellationToken);
 
         var totalAmount = request.TransactionTypeAmounts.Sum(x => x.Amount);

--- a/Commands/Handlers/Transaction/EditTransaction/EditTransactionHandler.cs
+++ b/Commands/Handlers/Transaction/EditTransaction/EditTransactionHandler.cs
@@ -20,7 +20,7 @@ public class EditTransactionHandler : IRequestHandler<EditTransactionCommand>
     {
         var financialYear =
             await _financialYearRepository.GetFinancialYearByTransactionId(request.Id, cancellationToken)
-            ?? throw new ArgumentException($"No transaction found for Id {request.Id}", nameof(request.Id));
+            ?? throw new ArgumentException($"No transaction found for Id {request.Id}", nameof(request));
 
         if (financialYear.StartDate <= request.ReceivedDateTime &&
            financialYear.EndDate >= request.ReceivedDateTime)
@@ -33,7 +33,7 @@ public class EditTransactionHandler : IRequestHandler<EditTransactionCommand>
             var transaction = financialYear.Transactions.First(x => x.Id == request.Id);
 
             var matchingFinancialYear =
-                await _financialYearRepository.GetFinancialYearByDateAsync(request.ReceivedDateTime,
+                await _financialYearRepository.GetFinancialYearByTransactionId(request.FinancialYearId,
                     cancellationToken)
                 ?? await _mediator.Send(new AddFinancialYearCommand(), cancellationToken);
 

--- a/Commands/Handlers/Transaction/EditTransaction/EditTransationCommand.cs
+++ b/Commands/Handlers/Transaction/EditTransaction/EditTransationCommand.cs
@@ -14,7 +14,8 @@ public record EditTransactionCommand(
     DateTimeOffset ReceivedDateTime,
     string Description,
     ICollection<TransactionTypeAmount> TransactionTypeAmounts,
-    ICollection<AttachmentFile> NewAttachmentFiles) : IRequest;
+    ICollection<AttachmentFile> NewAttachmentFiles,
+    Guid FinancialYearId) : IRequest;
 
 public class EditTransactionCommandValidator : AbstractValidator<EditTransactionCommand>
 {
@@ -50,6 +51,8 @@ public class EditTransactionCommandValidator : AbstractValidator<EditTransaction
         RuleForEach(x => x.NewAttachmentFiles)
             .SetValidator(new AttachmentValidator());
 
+        RuleFor(x => x.FinancialYearId)
+            .NotEmpty();
     }
 }
 

--- a/Domain/FinancialYear.cs
+++ b/Domain/FinancialYear.cs
@@ -21,6 +21,8 @@ public class FinancialYear
 
     public ICollection<Transaction> Transactions { get; private set; }
 
+    public string Name => $"{StartDate.Year} - {EndDate.Year}";
+
     public void Close()
     {
         if (IsClosed)

--- a/Domain/Interfaces/IFinancialYearRepository.cs
+++ b/Domain/Interfaces/IFinancialYearRepository.cs
@@ -8,5 +8,4 @@ public interface IFinancialYearRepository
     Task<FinancialYear?> GetMostRecentAsync(CancellationToken cancellationToken);
 
     Task<FinancialYear?> GetFinancialYearByTransactionId(Guid transactionId, CancellationToken cancellationToken);
-    Task<FinancialYear?> GetFinancialYearByDateAsync(DateTimeOffset dateTime, CancellationToken cancellationToken);
 }

--- a/Persistence/HaSpManContext.cs
+++ b/Persistence/HaSpManContext.cs
@@ -1,5 +1,4 @@
 using Domain;
-using Domain.Views;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Persistence/Repositories/FinancialYearRepository.cs
+++ b/Persistence/Repositories/FinancialYearRepository.cs
@@ -52,11 +52,4 @@ public class FinancialYearRepository : IFinancialYearRepository
             .Include(f => f.Transactions)
             .SingleOrDefaultAsync(x => x.Transactions.Any(t => t.Id == transactionId), cancellationToken);
     }
-
-    public Task<FinancialYear?> GetFinancialYearByDateAsync(DateTimeOffset dateTime, CancellationToken cancellationToken)
-    {
-        return _context.FinancialYears
-            .Include(f => f.Transactions)
-            .SingleOrDefaultAsync(x => x.StartDate <= dateTime && x.EndDate >= dateTime,cancellationToken);
-    }
 }

--- a/Queries/BankAccounts/SearchBankAccounts.cs
+++ b/Queries/BankAccounts/SearchBankAccounts.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using AutoMapper.QueryableExtensions;
 
 using Domain;
-using Domain.Views;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Queries/FinancialYears/FinancialYear.cs
+++ b/Queries/FinancialYears/FinancialYear.cs
@@ -1,0 +1,8 @@
+﻿namespace Queries.FinancialYears;
+
+public record FinancialYear(
+    Guid Id,
+    DateTimeOffset StartDateTimeOffset,
+    DateTimeOffset EndDateTimeOffset,
+    bool IsClosed,
+    string Name);

--- a/Queries/FinancialYears/GetFinancialYearByTransactionId.cs
+++ b/Queries/FinancialYears/GetFinancialYearByTransactionId.cs
@@ -1,0 +1,28 @@
+﻿
+using Microsoft.EntityFrameworkCore;
+
+using Persistence;
+
+namespace Queries.FinancialYears;
+
+public record GetFinancialYearByTransactionId(Guid TransactionId) : IRequest<FinancialYear?>;
+
+public class GetFinancialYearByTransactionIdHandler : IRequestHandler<GetFinancialYearByTransactionId, FinancialYear?>
+{
+    private readonly HaSpManContext _context;
+
+    public GetFinancialYearByTransactionIdHandler(HaSpManContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public Task<FinancialYear?> GetFinancialYearByTransactionId(Guid transactionId, CancellationToken ct)
+        => _context.FinancialYears
+            .AsNoTracking()
+            .Where(x => x.Transactions.Any(t => t.Id == transactionId))
+            .Select(x => new FinancialYear(x.Id, x.StartDate, x.EndDate, x.IsClosed, x.Name))
+            .SingleOrDefaultAsync(ct);
+
+    public Task<FinancialYear?> Handle(GetFinancialYearByTransactionId request, CancellationToken cancellationToken)
+        => GetFinancialYearByTransactionId(request.TransactionId, cancellationToken);
+}

--- a/Queries/FinancialYears/GetFinancialYearsQuery.cs
+++ b/Queries/FinancialYears/GetFinancialYearsQuery.cs
@@ -5,7 +5,6 @@ using Persistence;
 namespace Queries.FinancialYears;
 
 public record GetFinancialYearsQuery() : IRequest<IReadOnlyList<FinancialYear>>;
-public record FinancialYear(Guid Id, DateTimeOffset StartDateTimeOffset, DateTimeOffset EndDateTimeOffset, bool IsClosed);
 
 public class GetFinancialYearsHandler : IRequestHandler<GetFinancialYearsQuery, IReadOnlyList<FinancialYear>>
 {
@@ -23,7 +22,7 @@ public class GetFinancialYearsHandler : IRequestHandler<GetFinancialYearsQuery, 
 
         return financialYears
             .OrderByDescending(x => x.StartDate)
-            .Select(x => new FinancialYear(x.Id, x.StartDate, x.EndDate, x.IsClosed))
+            .Select(x => new FinancialYear(x.Id, x.StartDate, x.EndDate, x.IsClosed, x.Name))
             .ToList();
     }
 }

--- a/Queries/Transactions/ViewModels/TransactionDetail.cs
+++ b/Queries/Transactions/ViewModels/TransactionDetail.cs
@@ -1,5 +1,3 @@
-using Types;
-
 namespace Queries.Transactions.ViewModels;
 
 public record TransactionDetail(

--- a/Web/Extensions/TransactionTypeGroupExtensions.cs
+++ b/Web/Extensions/TransactionTypeGroupExtensions.cs
@@ -2,11 +2,11 @@
 
 using Web.Pages.Transactions;
 
-namespace Web;
+namespace Web.Extensions;
 
-public class TransactionTypes
+public static class TransactionTypeGroupExtensions
 {
-    public static IReadOnlyList<TransactionType> GetScopedTransactionTypes(TransactionTypeGroup group)
+    public static IReadOnlyList<TransactionType> GetScopedTransactionTypes(this TransactionTypeGroup group)
     {
         return group == TransactionTypeGroup.Debit
             ? new List<TransactionType>

--- a/Web/MapperProfiles/TransactionProfile.cs
+++ b/Web/MapperProfiles/TransactionProfile.cs
@@ -48,7 +48,8 @@ public class TransactionProfile : Profile
             .ForMember(x => x.TransactionAttachments, o => o.MapFrom(x => x.TransactionAttachments))
             .ForMember(x => x.NewMembershipExpirationDate, o => o.Ignore())
             .ForMember(x => x.ApplyMembershipCalculation, o => o.Ignore())
-            .ForMember(x => x.NewTransactionAttachments, o => o.Ignore());
+            .ForMember(x => x.NewTransactionAttachments, o => o.Ignore())
+            .ForMember(m => m.FinancialYearId, o => o.Ignore());
 
         CreateMap<TransactionTypeAmount, TransactionTypeAmountForm>();
 

--- a/Web/Models/TransactionForm.cs
+++ b/Web/Models/TransactionForm.cs
@@ -33,6 +33,9 @@ public class TransactionForm
     [Required(AllowEmptyStrings = false), StringLength(1000)]
     public string? Description { get; set; }
 
+    [Required]
+    public Guid? FinancialYearId { get; set; }
+
     [ValidateComplexType]
     public ICollection<TransactionTypeAmountForm> TransactionTypeAmounts { get; set; }
 

--- a/Web/Pages/FinancialYears/FinancialYears.razor
+++ b/Web/Pages/FinancialYears/FinancialYears.razor
@@ -18,6 +18,9 @@
     </ToolBarContent>
     <HeaderContent>
         <MudTh>
+            Name
+        </MudTh>
+        <MudTh>
             Start date
         </MudTh>
         <MudTh>
@@ -31,9 +34,10 @@
         </MudTh>
     </HeaderContent>
     <RowTemplate>
-        <MudTd DataLabel="Name">@context.StartDateTimeOffset.Date.ToString("dd-MM-yyyy")</MudTd>
-        <MudTd DataLabel="AccountNumber">@context.EndDateTimeOffset.Date.ToString("dd-MM-yyyy")</MudTd>
-        <MudTd DataLabel="AccountNumber">@context.IsClosed</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="StartDate">@context.StartDateTimeOffset.Date.ToString("dd-MM-yyyy")</MudTd>
+        <MudTd DataLabel="EndDate">@context.EndDateTimeOffset.Date.ToString("dd-MM-yyyy")</MudTd>
+        <MudTd DataLabel="IsClosed">@context.IsClosed</MudTd>
         <MudTd>
             @if (!@context.IsClosed)
             {

--- a/Web/Pages/Transactions/EditTransaction.razor
+++ b/Web/Pages/Transactions/EditTransaction.razor
@@ -23,18 +23,18 @@
     <DataAnnotationsValidator />
 
     <TransactionForm IsNew="false"
-        IsSearchForMembership="Transaction.Counterparty.MemberId.HasValue"
-        Transaction="@Transaction"
-        TransactionTypeGroup="_transactionTypeGroup" />
+                     IsSearchForMembership="Transaction.Counterparty.MemberId.HasValue"
+                     Transaction="@Transaction"
+                     TransactionTypeGroup="_transactionTypeGroup" />
 
     <MudItem Class="d-flex justify-start" xs="12">
         <MudButton ButtonType="ButtonType.Submit"
-            Class="my-8"
-            Color="Color.Primary"
-            DisableElevation="true"
-            Size="Size.Large"
-            Variant="Variant.Filled"
-            Disabled="@ReadOnly">
+                   Class="my-8"
+                   Color="Color.Primary"
+                   DisableElevation="true"
+                   Size="Size.Large"
+                   Variant="Variant.Filled"
+                   Disabled="@ReadOnly">
             Save transaction
         </MudButton>
     </MudItem>
@@ -66,18 +66,19 @@
         var expirationDate = Transaction.NewMembershipExpirationDate;
         var applyCalculation = Transaction.ApplyMembershipCalculation;
         var command = new EditTransactionCommand(
-        Id: TransactionId,
-        CounterPartyName: Transaction.Counterparty.Name!,
-        MemberId: Transaction.Counterparty.MemberId,
-        BankAccountId: Transaction.BankAccountId.GetValueOrDefault(),
-        ReceivedDateTime: new DateTimeOffset(Transaction.ReceivedDateTime!.Value),
-        Description: Transaction.Description!,
-        TransactionTypeAmounts: Transaction.TransactionTypeAmounts
-        .Select(x => new TransactionTypeAmount(x.TransactionType!.Value, x.Amount!.Value))
-        .ToList(),
-        NewAttachmentFiles: Transaction.NewTransactionAttachments
-        .Select(x => new AttachmentFile(x.FileName, x.ContentType, x.UnsafePath))
-        .ToList());
+            Id: TransactionId,
+            CounterPartyName: Transaction.Counterparty.Name!,
+            MemberId: Transaction.Counterparty.MemberId,
+            BankAccountId: Transaction.BankAccountId.GetValueOrDefault(),
+            ReceivedDateTime: new DateTimeOffset(Transaction.ReceivedDateTime!.Value),
+            Description: Transaction.Description!,
+            TransactionTypeAmounts: Transaction.TransactionTypeAmounts
+                .Select(x => new TransactionTypeAmount(x.TransactionType!.Value, x.Amount!.Value))
+                .ToList(),
+            NewAttachmentFiles: Transaction.NewTransactionAttachments
+                .Select(x => new AttachmentFile(x.FileName, x.ContentType, x.UnsafePath))
+                .ToList(),
+            FinancialYearId: Transaction.FinancialYearId!.Value);
 
         await Mediator.Send(command);
         if (memberId.HasValue && expirationDate.HasValue && applyCalculation)

--- a/Web/Pages/Transactions/TransactionForm.razor
+++ b/Web/Pages/Transactions/TransactionForm.razor
@@ -1,442 +1,223 @@
 ﻿@using Types
-@using Web.Models
-@using Queries.Members.Handlers.GetBankAccountInfos
-@using Queries.Members.Handlers.GetMemberById
-@using Queries.Members.ViewModels
 @using Queries.Members.Handlers.AutocompleteMember
-@using Queries.Transactions.GetAttachment
-@inject IWebHostEnvironment Environment
-
-@inject IDialogService dialogService
-
-@inject IMediator mediator;
-
-@inject IJSRuntime JS;
 
 <div class="d-flex flex-column justify-start align-start mw-13">
-<MudCard class="mb-6 mt-2 pb-3 expand">
-    <MudCardHeader>
-        <MudText Typo="Typo.h5">Type</MudText>
-    </MudCardHeader>
-    <MudCardContent>
-        @if (IsNew)
-        {
-            <MudGrid>
-                <MudItem xs="6">
-                    <MudRadioGroup SelectedOption="TransactionTypeGroup" SelectedOptionChanged="OnChangeTypeGroup" T="TransactionTypeGroup">
-                        @foreach (var transactionTypeGroup in Enum.GetValues<TransactionTypeGroup>())
-                        {
-                            <MudRadio Option="transactionTypeGroup">@transactionTypeGroup.GetDescription()</MudRadio>
-                        }
+    <MudCard class="mb-6 mt-2 pb-3 expand">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Type</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            @if (IsNew)
+            {
+                <MudGrid>
+                    <MudItem xs="6">
+                        <MudRadioGroup SelectedOption="TransactionTypeGroup" SelectedOptionChanged="OnChangeTypeGroup"
+                                       T="TransactionTypeGroup">
+                            @foreach (var transactionTypeGroup in Enum.GetValues<TransactionTypeGroup>())
+                            {
+                                <MudRadio Option="transactionTypeGroup">@transactionTypeGroup.GetDescription()</MudRadio>
+                            }
+                        </MudRadioGroup>
+                    </MudItem>
+                </MudGrid>
+            }
+            else
+            {
+                @TransactionTypeGroup.GetDescription()
+            }
+        </MudCardContent>
+    </MudCard>
+
+    <MudCard class="mb-6 mt-2 pb-3 expand">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Involved parties</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudGrid Class="flex-wrap" Justify="Justify.SpaceBetween" Spacing="2">
+                <MudItem xs="2">
+                    <MudRadioGroup @bind-SelectedOption="IsSearchForMembership">
+                        <MudRadio Option="false">Non-members</MudRadio>
+                        <MudRadio Option="true">Members</MudRadio>
                     </MudRadioGroup>
                 </MudItem>
-            </MudGrid>
-        }
-        else
-        {
-            @TransactionTypeGroup.GetDescription()
-        }
-    </MudCardContent>
-</MudCard>
-
-<MudCard class="mb-6 mt-2 pb-3 expand">
-    <MudCardHeader>
-        <MudText Typo="Typo.h5">Involved parties</MudText>
-    </MudCardHeader>
-    <MudCardContent>
-        <MudGrid Class="flex-wrap"
-                 Justify="Justify.SpaceBetween"
-                 Spacing="2">
-            <MudItem xs="2">
-                <MudRadioGroup @bind-SelectedOption="IsSearchForMembership">
-                    <MudRadio Option="false">Non-members</MudRadio>
-                    <MudRadio Option="true">Members</MudRadio>
-                </MudRadioGroup>
-            </MudItem>
-            <MudItem xs="3">
-                @if (IsSearchForMembership)
-                {
-                    <MudAutocomplete ValueChanged="OnChangeMember"
-                                     Label="Members"
-                                     SearchFunc="SearchForMembers"
-                                     Value="Transaction.Counterparty"
-                                     T="AutocompleteCounterparty"
-                                     ToStringFunc="ac => ac?.Name"
-                                     Variant="Variant.Outlined"
-                                     For="@(() => Transaction.Counterparty)">
-                    </MudAutocomplete>
-                }
-                else
-                {
-                    <MudAutocomplete @bind-Value="Transaction.Counterparty"
-                                     CoerceText="true"
-                                     CoerceValue="true"
-                                     Converter="@counterPartyConverter"
-                                     Label="Non members"
-                                     SearchFunc="SearchForNonMembers"
-                                     T="AutocompleteCounterparty"
-                                     ToStringFunc="ac => ac?.Name"
-                                     Variant="Variant.Outlined"
-                                     For="@(() => Transaction.Counterparty)">
-                    </MudAutocomplete>
-                }
-            </MudItem>
-
-            <MudItem xs="2" sm="1">
-                @{
-                    var icon = TransactionTypeGroup switch {
-                        TransactionTypeGroup.Debit => Icons.Material.Filled.ArrowForward,
-                        TransactionTypeGroup.Credit => Icons.Material.Filled.ArrowBack,
-                        _ => Icons.Material.Filled.Block
-                        };
-                    <MudIcon Class="mt-4" Icon="@icon"/>
-                }
-            </MudItem>
-            <MudItem xs="6" sm="3">
-                <MudSelect @bind-Value="Transaction.BankAccountId" Class="min-w-3"
-                           Label="Select bank account"
-                           Variant="Variant.Outlined">
-                    @foreach (var item in _bankAccounts)
+                <MudItem xs="3">
+                    @if (IsSearchForMembership)
                     {
-                        <MudSelectItem Value="@item?.Id">@item?.Name</MudSelectItem>
+                        <MudAutocomplete ValueChanged="OnChangeMember" Label="Members" SearchFunc="SearchForMembers"
+                                         Value="Transaction.Counterparty" T="AutocompleteCounterparty" ToStringFunc="ac => ac?.Name"
+                                         Variant="Variant.Outlined" For="@(() => Transaction.Counterparty)">
+                        </MudAutocomplete>
                     }
-                </MudSelect>
-            </MudItem>
-            <MudItem xs="3">
-                @{
-                    if (!_bankAccounts.Any())
+                    else
                     {
-                        <MudButton Class="mt-4"
-                                   Color="Color.Primary"
-                                   @onclick="OpenAddBankAccountDialog"
-                                   Variant="Variant.Filled">
-                            Add bank account
-                        </MudButton>
+                        <MudAutocomplete @bind-Value="Transaction.Counterparty" CoerceText="true" CoerceValue="true"
+                                         Converter="@_counterPartyConverter" Label="Non members" SearchFunc="SearchForNonMembers"
+                                         T="AutocompleteCounterparty" ToStringFunc="ac => ac?.Name" Variant="Variant.Outlined"
+                                         For="@(() => Transaction.Counterparty)">
+                        </MudAutocomplete>
                     }
-                }
-            </MudItem>
-        </MudGrid>
-    </MudCardContent>
-</MudCard>
-
-<MudCard class="mb-6 mt-2 pb-3 expand">
-    <MudCardHeader>
-        <MudText Typo="Typo.h5">
-            Transaction
-        </MudText>
-    </MudCardHeader>
-    <MudCardContent>
-        <MudGrid Justify="Justify.FlexStart">
-            <MudItem xs="12">
-                <MudTextField @bind-Text="Transaction.Description"
-                              For="() => Transaction.Description"
-                              Label="Description"
-                              T="string"/>
-            </MudItem>
-            <MudItem md="4"
-                     sm="6"
-                     xs="12">
-                <MudDatePicker AutoClose="true"
-                               @bind-Date="Transaction.ReceivedDateTime"
-                               DateFormat="dd/MM/yyyy"
-                               Editable="true"
-                               Label="Transaction date"
-                               Mask="@(new DateMask("dd/MM/yyyy"))"
-                               MaxDate="DateTime.Now"
-                               For="@(() => Transaction.ReceivedDateTime)"
-                               @ref="_picker">
-                    <PickerActions>
-                        <MudButton Class="mr-auto align-self-start"
-                                   OnClick="@(() => _picker.Clear())">
-                            Clear
-                        </MudButton>
-                    </PickerActions>
-                </MudDatePicker>
-            </MudItem>
-        </MudGrid>
-    </MudCardContent>
-</MudCard>
-<MudCard class="mb-6 mt-2 pb-3 expand">
-    <MudCardHeader>
-        <MudText Typo="Typo.h5">Amount</MudText>
-    </MudCardHeader>
-    <MudCardContent>
-        <MudGrid>
-            @foreach (var transactionType in Transaction.TransactionTypeAmounts)
-            {
-                <MudItem xs="6">
-                    <MudNumericField Value="transactionType.Amount"
-                                     ValueChanged="value => OnAmountChanged(transactionType, value)"
-                                     Label="Amount (€)"
-                                     Min="0"
-                                     For="@(() => transactionType.Amount)"
-                                     T="decimal?">
-                    </MudNumericField>
                 </MudItem>
 
-                <MudItem xs="6">
-                    <MudSelect @bind-Value="transactionType.TransactionType"
-                               Label="Select transaction type"
-                               Variant="Variant.Outlined"
-                               T="TransactionType?"
-                               For="@(() => transactionType.TransactionType)">
-
-                        <MudSelectItem T="TransactionType?" Value="@null"></MudSelectItem>
-                        @foreach (var item in _transactionTypes)
+                <MudItem xs="2" sm="1">
+                    @{
+                        var icon = TransactionTypeGroup switch
                         {
-                            <MudSelectItem T="TransactionType?" Value="@item">@item.GetDescription()</MudSelectItem>
+                            TransactionTypeGroup.Debit => Icons.Material.Filled.ArrowForward,
+                            TransactionTypeGroup.Credit => Icons.Material.Filled.ArrowBack,
+                            _ => Icons.Material.Filled.Block
+                        };
+                        <MudIcon Class="mt-4" Icon="@icon" />
+                    }
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <MudSelect @bind-Value="Transaction.BankAccountId" Class="min-w-3" Label="Select bank account"
+                               Variant="Variant.Outlined">
+                        @foreach (var item in _bankAccounts)
+                        {
+                            <MudSelectItem Value="@item?.Id">@item?.Name</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
-            }
-        </MudGrid>
-        <MudDivider Class="my-2"></MudDivider>
-        <MudText>
-            Sum of all types: <strong>€@Transaction.TransactionTypeAmounts.Sum(x => x.Amount)</strong>.
-            This value should match the total amount of the transaction
-        </MudText>
-        @if (CanExtendMembership && SelectedMember != null)
-        {
-            <MudCheckBox Color="Color.Secondary" @bind-Checked="Transaction.ApplyMembershipCalculation">Extend membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths more month(s) of membership</MudCheckBox>
-
-            <MudGrid>
-                <MudDatePicker Label="New expiration month"
-                               @bind-Date="Transaction.NewMembershipExpirationDate"
-                               DisableToolbar="true"
-                               DateFormat="dd/MM/yyyy"
-                               MinDate="DateTime.Today"/>
+                <MudItem xs="3">
+                    @{
+                        if (!_bankAccounts.Any())
+                        {
+                            <MudButton Class="mt-4" Color="Color.Primary" @onclick="OpenAddBankAccountDialog"
+                                       Variant="Variant.Filled">
+                                Add bank account
+                            </MudButton>
+                        }
+                    }
+                </MudItem>
             </MudGrid>
-        }
+        </MudCardContent>
+    </MudCard>
 
-    </MudCardContent>
-</MudCard>
-<MudCard class="mb-6 mt-2 pb-3 expand">
-    <MudList Clickable="true">
-        <MudListSubheader>
-            Attachments
-        </MudListSubheader>
-        @foreach (var attachment in Transaction.NewTransactionAttachments)
-        {
-            <MudListItem Icon="@Icons.Material.Outlined.SaveAs"
-                         OnClick="() => Download(attachment.FileName)">
-                @attachment.FileName
-            </MudListItem>
-        }
-        @foreach (var attachment in Transaction.TransactionAttachments)
-        {
-            <MudListItem Icon="@Icons.Material.Outlined.Save"
-                         OnClick="() => Download(attachment.FileName)">
-                @attachment.FileName
-            </MudListItem>
-        }
-    </MudList>
-</MudCard>
-<MudCard class="mb-6 mt-2 pb-3 expand">
-    <MudCardHeader>
-        <MudText Type="Typo.h5">Attachments</MudText>
-    </MudCardHeader>
-    <MudCardContent>
-        <InputFile hidden
-                   id="attachmentFilePicker"
-                   multiple
-                   OnChange="UploadFiles"/>
-        <MudButton Color="Color.Primary"
-                   for="attachmentFilePicker"
-                   HtmlTag="label"
-                   StartIcon="@Icons.Material.Filled.CloudUpload"
-                   Variant="Variant.Filled">
-            Upload new attachment(s)
-        </MudButton>
-        @if (FileErrorMessage != null)
-        {
-            <p class="pa red-text text-darken-2">@FileErrorMessage</p>
-        }
-    </MudCardContent>
-</MudCard>
-<ValidationSummary></ValidationSummary>
+    <MudCard class="mb-6 mt-2 pb-3 expand">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">
+                Transaction
+            </MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudGrid Justify="Justify.FlexStart">
+                <MudItem xs="12">
+                    <MudTextField @bind-Text="Transaction.Description" For="() => Transaction.Description"
+                                  Label="Description" T="string" />
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <MudSelect Value="@Transaction.FinancialYearId" Class="min-w-3" Label="Select financial year"
+                               Variant="Variant.Outlined" ValueChanged="value => SetMinReceivedDate(value)" T="Guid?">
+                        @foreach (var item in _financialYears)
+                        {
+                            <MudSelectItem Value="@item?.Id" Disabled="@item!.IsClosed">
+                                @if (@item.IsClosed)
+                                {
+                                    <MudIcon Icon="@Icons.Material.Filled.Lock" />
+                                }
+                                @item?.Name
+                            </MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem md="4" sm="6" xs="12">
+                    <MudDatePicker AutoClose="true" @bind-Date="Transaction.ReceivedDateTime" DateFormat="dd/MM/yyyy"
+                                   Editable="true" Label="Transaction date" Mask="@(new DateMask("dd/MM/yyyy"))"
+                                   MinDate="MinReceivedDateTime" MaxDate="DateTime.Now" For="@(() => Transaction.ReceivedDateTime)" @ref="_picker"
+                                   Disabled="@(Transaction.FinancialYearId == null)">
+                        <PickerActions>
+                            <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.Clear())">
+                                Clear
+                            </MudButton>
+                        </PickerActions>
+                    </MudDatePicker>
+                </MudItem>
+            </MudGrid>
+        </MudCardContent>
+    </MudCard>
+    <MudCard class="mb-6 mt-2 pb-3 expand">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Amount</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudGrid>
+                @foreach (var transactionType in Transaction.TransactionTypeAmounts)
+                {
+                    <MudItem xs="6">
+                        <MudNumericField Value="transactionType.Amount"
+                                         ValueChanged="value => OnAmountChanged(transactionType, value)" Label="Amount (€)" Min="0"
+                                         For="@(() => transactionType.Amount)" T="decimal?">
+                        </MudNumericField>
+                    </MudItem>
+
+                    <MudItem xs="6">
+                        <MudSelect @bind-Value="transactionType.TransactionType" Label="Select transaction type"
+                                   Variant="Variant.Outlined" T="TransactionType?" For="@(() => transactionType.TransactionType)">
+
+                            <MudSelectItem T="TransactionType?" Value="@null"></MudSelectItem>
+                            @foreach (var item in _transactionTypes)
+                            {
+                                <MudSelectItem T="TransactionType?" Value="@item">@item.GetDescription()</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                }
+            </MudGrid>
+            <MudDivider Class="my-2"></MudDivider>
+            <MudText>
+                Sum of all types: <strong>€@Transaction.TransactionTypeAmounts.Sum(x => x.Amount)</strong>.
+                This value should match the total amount of the transaction
+            </MudText>
+            @if (CanExtendMembership && SelectedMember != null)
+            {
+                <MudCheckBox Color="Color.Secondary" @bind-Checked="Transaction.ApplyMembershipCalculation">
+                    Extend
+                    membership for @SelectedMember.FirstName: €@SelectedMember.MembershipFee. This gives @AmountOfMonths
+                    more month(s) of membership
+                </MudCheckBox>
+
+                <MudGrid>
+                    <MudDatePicker Label="New expiration month" @bind-Date="Transaction.NewMembershipExpirationDate"
+                                   DisableToolbar="true" DateFormat="dd/MM/yyyy" MinDate="DateTime.Today" />
+                </MudGrid>
+            }
+
+        </MudCardContent>
+    </MudCard>
+    <MudCard class="mb-6 mt-2 pb-3 expand">
+        <MudList Clickable="true">
+            <MudListSubheader>
+                Attachments
+            </MudListSubheader>
+            @foreach (var attachment in Transaction.NewTransactionAttachments)
+            {
+                <MudListItem Icon="@Icons.Material.Outlined.SaveAs" OnClick="() => Download(attachment.FileName)">
+                    @attachment.FileName
+                </MudListItem>
+            }
+            @foreach (var attachment in Transaction.TransactionAttachments)
+            {
+                <MudListItem Icon="@Icons.Material.Outlined.Save" OnClick="() => Download(attachment.FileName)">
+                    @attachment.FileName
+                </MudListItem>
+            }
+        </MudList>
+    </MudCard>
+    <MudCard class="mb-6 mt-2 pb-3 expand">
+        <MudCardHeader>
+            <MudText Type="Typo.h5">Attachments</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <InputFile hidden id="attachmentFilePicker" multiple OnChange="UploadFiles" />
+            <MudButton Color="Color.Primary" for="attachmentFilePicker" HtmlTag="label"
+                       StartIcon="@Icons.Material.Filled.CloudUpload" Variant="Variant.Filled">
+                Upload new attachment(s)
+            </MudButton>
+            @if (FileErrorMessage != null)
+            {
+                <p class="pa red-text text-darken-2">@FileErrorMessage</p>
+            }
+        </MudCardContent>
+    </MudCard>
+    <ValidationSummary></ValidationSummary>
 </div>
-
-@code {
-
-    [Parameter]
-    public Models.TransactionForm Transaction { get; set; } = new();
-
-    [Parameter]
-    public bool IsSearchForMembership { get; set; }
-
-    [Parameter]
-    public TransactionTypeGroup TransactionTypeGroup { get; set; }
-
-    [Parameter]
-    public EventCallback<TransactionTypeGroup> TransactionTypeGroupChanged{ get; set; }
-
-    [Parameter]
-    public bool IsNew { get; set; }
-
-    public string? FileErrorMessage { get; set; }
-
-    private IReadOnlyList<BankAccountInfo> _bankAccounts = new List<BankAccountInfo>();
-
-    private IReadOnlyList<TransactionType> _transactionTypes = new List<TransactionType>();
-
-    private DateTime? _newExpirationDate;
-
-    private int AmountOfMonths { get; set; }
-
-    private MemberDetail? SelectedMember { get; set; }
-
-    private bool CanExtendMembership =>
-        Transaction.TransactionTypeAmounts.Any(x => x.TransactionType == TransactionType.DebitMemberFee) &&
-        Transaction.Counterparty.MemberId.HasValue &&
-        SelectedMember != null &&
-        SelectedMember.MembershipFee != 0;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await GetAllBankAccounts();
-        SetTransactionTypes();
-    }
-
-    private void SetTransactionTypes()
-    {
-        _transactionTypes = TransactionTypes.GetScopedTransactionTypes(TransactionTypeGroup);
-    }
-
-    MudDatePicker _picker = new();
-    private int _maxAllowedSize = 1024 * 1024 * 10;
-    private IReadOnlyList<string> _allowedFileTypes = new List<string> { "pdf", "doc", "docx", "jpg", "jpeg", "png", "gif" };
-
-    private async Task<IEnumerable<AutocompleteCounterparty>> SearchForMembers(string searchString)
-    {
-        if (string.IsNullOrEmpty(searchString))
-        {
-            return new List<AutocompleteCounterparty>();
-        }
-        var response = await mediator.Send(new AutocompleteCounterpartyQuery(searchString, true));
-        return response.Counterparties;
-    }
-
-    private async Task<IEnumerable<AutocompleteCounterparty>> SearchForNonMembers(string searchString)
-    {
-        var response = await mediator.Send(new AutocompleteCounterpartyQuery(searchString, false));
-
-        return response.Counterparties;
-    }
-
-    private async Task GetAllBankAccounts()
-    {
-        _bankAccounts = await mediator.Send(new GetBankAccountInfos());
-
-        if (_bankAccounts.Count == 1 && Transaction.BankAccountId == null)
-        {
-            Transaction.BankAccountId = _bankAccounts[0].Id;
-        }
-    }
-
-    private async Task OpenAddBankAccountDialog()
-    {
-        var dialog = dialogService.Show<AddBankAccountDialog>("Add bank account");
-        var result = await dialog.Result;
-        if (!result.Canceled && result.Data is true)
-        {
-            await GetAllBankAccounts();
-        }
-    }
-
-    Converter<AutocompleteCounterparty> counterPartyConverter = new()
-    {
-        SetFunc = value => value?.Name ?? "",
-        GetFunc = text => new AutocompleteCounterparty(text ?? "", null)
-    };
-
-    private async Task UploadFiles(InputFileChangeEventArgs e)
-    {
-        FileErrorMessage = string.Empty;
-        var entries = e.GetMultipleFiles();
-        var notAllowedFileTypes = entries.Any(x => !_allowedFileTypes.Any(fileType => x.Name.EndsWith(fileType)));
-        if (notAllowedFileTypes)
-        {
-            var joinedFileTypes = string.Join(", ", _allowedFileTypes);
-            FileErrorMessage = $"Some of the files are not of the supported file types ({joinedFileTypes})";
-            return;
-        }
-        var overMaxFileSize = entries.Any(x => x.Size > _maxAllowedSize);
-        if (overMaxFileSize)
-        {
-            FileErrorMessage = "Some of the files are too large (max 10mb)";
-            return;
-        }
-        var existingFileNames = Transaction.TransactionAttachments.Select(x => x.FileName).ToList();
-        var newFiles = entries.Where(x => existingFileNames.All(fileName => fileName != x.Name));
-
-        foreach (var file in newFiles)
-        {
-            var trustedFileNameForFileStorage = Path.GetRandomFileName();
-            var directory = Path.Combine(Environment.ContentRootPath,
-                Environment.EnvironmentName, "unsafe_uploads");
-            Directory.CreateDirectory(directory);
-            var path = Path.Combine(directory, trustedFileNameForFileStorage);
-
-            await using FileStream fs = new(path, FileMode.Create);
-            await file.OpenReadStream(_maxAllowedSize).CopyToAsync(fs);
-            var transaction = new NewTransactionAttachment(file.Name, file.ContentType, path);
-            Transaction.NewTransactionAttachments.Add(transaction);
-        }
-    }
-
-    private async Task Download(string attachmentFileName)
-    {
-        var attachment = await mediator.Send(new GetAttachmentQuery(Transaction.Id, attachmentFileName));
-        var fileStream = new MemoryStream(attachment.Bytes);
-        using var streamRef = new DotNetStreamReference(fileStream);
-        await JS.InvokeVoidAsync("downloadFileFromStream", attachment.Name, streamRef); // THIS FEELS SOOOO DIRTY
-    }
-
-    private async Task OnChangeMember(AutocompleteCounterparty counterparty)
-    {
-        Transaction.Counterparty = counterparty;
-        await CalculateMembershipExpirationDate();
-    }
-
-    private async Task OnChangeTypeGroup(TransactionTypeGroup typeGroup)
-    {
-        if (TransactionTypeGroup == typeGroup)
-            return;
-
-        TransactionTypeGroup = typeGroup;
-        await TransactionTypeGroupChanged.InvokeAsync(typeGroup);
-        SetTransactionTypes();
-        foreach (var transactionTypeAmount in Transaction.TransactionTypeAmounts)
-            transactionTypeAmount.TransactionType = null;
-    }
-
-    private async Task OnAmountChanged(TransactionTypeAmountForm transactionTypeAmount, decimal? value)
-    {
-        transactionTypeAmount.Amount = value;
-        await CalculateMembershipExpirationDate();
-    }
-
-
-    private async Task CalculateMembershipExpirationDate()
-    {
-        if (!Transaction.Counterparty.MemberId.HasValue)
-        {
-            return;
-        }
-        var memberId = Transaction.Counterparty.MemberId.Value;
-        var member = await mediator.Send(new GetMemberByIdQuery(memberId));
-        SelectedMember = member;
-        var transactionTypeForMembershipFee =
-            Transaction.TransactionTypeAmounts.SingleOrDefault(x => x.TransactionType == TransactionType.DebitMemberFee);
-        if (transactionTypeForMembershipFee != null &&
-            transactionTypeForMembershipFee.Amount is not null or 0 &&
-            SelectedMember.MembershipExpiryDate.HasValue && SelectedMember.MembershipFee != 0)
-        {
-            AmountOfMonths = (int)Math.Floor((double)transactionTypeForMembershipFee.Amount / SelectedMember.MembershipFee);
-            _newExpirationDate = SelectedMember.MembershipExpiryDate.Value.AddMonths(AmountOfMonths).Date;
-            Transaction.NewMembershipExpirationDate = _newExpirationDate;
-        }
-    }
-
-
-}

--- a/Web/Pages/Transactions/TransactionForm.razor.cs
+++ b/Web/Pages/Transactions/TransactionForm.razor.cs
@@ -1,0 +1,256 @@
+using MediatR;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.JSInterop;
+
+using MudBlazor;
+
+using Queries.FinancialYears;
+using Queries.Members.Handlers.AutocompleteMember;
+using Queries.Members.Handlers.GetBankAccountInfos;
+using Queries.Members.Handlers.GetMemberById;
+using Queries.Members.ViewModels;
+using Queries.Transactions.GetAttachment;
+
+using Types;
+
+using Web.Extensions;
+using Web.Models;
+
+namespace Web.Pages.Transactions;
+
+public partial class TransactionForm : ComponentBase
+{
+    [Inject]
+    private IWebHostEnvironment Environment { get; set; } = default!;
+
+    [Inject]
+    private IDialogService DialogService { get; set; } = default!;
+
+    [Inject]
+    private IMediator Mediator { get; set; } = default!;
+
+    [Inject]
+    private IJSRuntime JS { get; set; } = default!;
+
+    [Parameter]
+    public Models.TransactionForm Transaction { get; set; } = new();
+
+    [Parameter]
+    public bool IsSearchForMembership { get; set; }
+
+    [Parameter]
+    public TransactionTypeGroup TransactionTypeGroup { get; set; }
+
+    [Parameter]
+    public EventCallback<TransactionTypeGroup> TransactionTypeGroupChanged { get; set; }
+
+    [Parameter]
+    public bool IsNew { get; set; }
+
+    public string? FileErrorMessage { get; set; }
+
+    private IReadOnlyList<BankAccountInfo> _bankAccounts = new List<BankAccountInfo>();
+
+    private IReadOnlyList<TransactionType> _transactionTypes = new List<TransactionType>();
+
+    private IReadOnlyList<FinancialYear> _financialYears = new List<FinancialYear>();
+
+    private DateTime? _newExpirationDate;
+
+    private int AmountOfMonths { get; set; }
+
+    private MemberDetail? SelectedMember { get; set; }
+
+    private bool CanExtendMembership => Transaction.TransactionTypeAmounts
+        .Any(x => x.TransactionType == Types.TransactionType.DebitMemberFee) &&
+        Transaction.Counterparty.MemberId.HasValue &&
+        SelectedMember != null &&
+        SelectedMember.MembershipFee != 0;
+
+    private DateTime? MinReceivedDateTime { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GetAllBankAccounts();
+        SetTransactionTypes();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await TrySetFinancialYearId();
+        await SetFinancialYears();
+    }
+
+    private void SetTransactionTypes()
+    {
+        _transactionTypes = TransactionTypeGroup.GetScopedTransactionTypes();
+    }
+
+    private MudDatePicker _picker = new();
+    private readonly int _maxAllowedSize = 1024 * 1024 * 10;
+    private readonly IReadOnlyList<string> _allowedFileTypes = new List<string> {
+        "pdf", "doc", "docx", "jpg", "jpeg", "png", "gif" };
+
+    private async Task<IEnumerable<AutocompleteCounterparty>> SearchForMembers(string searchString)
+    {
+        if (string.IsNullOrEmpty(searchString))
+        {
+            return new List<AutocompleteCounterparty>();
+        }
+        var response = await Mediator.Send(new AutocompleteCounterpartyQuery(searchString, true));
+        return response.Counterparties;
+    }
+
+    private async Task<IEnumerable<AutocompleteCounterparty>> SearchForNonMembers(string searchString)
+    {
+        var response = await Mediator.Send(new AutocompleteCounterpartyQuery(searchString, false));
+
+        return response.Counterparties;
+    }
+
+    private async Task GetAllBankAccounts()
+    {
+        _bankAccounts = await Mediator.Send(new GetBankAccountInfos());
+
+        if (_bankAccounts.Count == 1 && Transaction.BankAccountId == null)
+        {
+            Transaction.BankAccountId = _bankAccounts[0].Id;
+        }
+    }
+
+    private async Task OpenAddBankAccountDialog()
+    {
+        var dialog = DialogService.Show<AddBankAccountDialog>("Add bank account");
+        var result = await dialog.Result;
+        if (!result.Canceled && result.Data is true)
+        {
+            await GetAllBankAccounts();
+        }
+    }
+
+    private readonly Converter<AutocompleteCounterparty> _counterPartyConverter = new()
+    {
+        SetFunc = value => value?.Name ?? "",
+        GetFunc = text => new AutocompleteCounterparty(text ?? "", null)
+    };
+
+    private async Task UploadFiles(InputFileChangeEventArgs e)
+    {
+        FileErrorMessage = string.Empty;
+        var entries = e.GetMultipleFiles();
+        var notAllowedFileTypes = entries.Any(x => !_allowedFileTypes.Any(fileType => x.Name.EndsWith(fileType)));
+        if (notAllowedFileTypes)
+        {
+            var joinedFileTypes = string.Join(", ", _allowedFileTypes);
+            FileErrorMessage = $"Some of the files are not of the supported file types ({joinedFileTypes})";
+            return;
+        }
+        var overMaxFileSize = entries.Any(x => x.Size > _maxAllowedSize);
+        if (overMaxFileSize)
+        {
+            FileErrorMessage = "Some of the files are too large (max 10mb)";
+            return;
+        }
+        var existingFileNames = Transaction.TransactionAttachments.Select(x => x.FileName).ToList();
+        var newFiles = entries.Where(x => existingFileNames.All(fileName => fileName != x.Name));
+
+        foreach (var file in newFiles)
+        {
+            var trustedFileNameForFileStorage = Path.GetRandomFileName();
+            var directory = Path.Combine(Environment.ContentRootPath,
+            Environment.EnvironmentName, "unsafe_uploads");
+            Directory.CreateDirectory(directory);
+            var path = Path.Combine(directory, trustedFileNameForFileStorage);
+
+            await using FileStream fs = new(path, FileMode.Create);
+            await file.OpenReadStream(_maxAllowedSize).CopyToAsync(fs);
+            var transaction = new NewTransactionAttachment(file.Name, file.ContentType, path);
+            Transaction.NewTransactionAttachments.Add(transaction);
+        }
+    }
+
+    private async Task Download(string attachmentFileName)
+    {
+        var attachment = await Mediator.Send(new GetAttachmentQuery(Transaction.Id, attachmentFileName));
+        var fileStream = new MemoryStream(attachment.Bytes);
+        using var streamRef = new DotNetStreamReference(fileStream);
+        await JS.InvokeVoidAsync("downloadFileFromStream", attachment.Name, streamRef); // THIS FEELS SOOOO DIRTY
+    }
+
+    private async Task OnChangeMember(AutocompleteCounterparty counterparty)
+    {
+        Transaction.Counterparty = counterparty;
+        await CalculateMembershipExpirationDate();
+    }
+
+    private async Task OnChangeTypeGroup(TransactionTypeGroup typeGroup)
+    {
+        if (TransactionTypeGroup == typeGroup)
+            return;
+
+        TransactionTypeGroup = typeGroup;
+        await TransactionTypeGroupChanged.InvokeAsync(typeGroup);
+        SetTransactionTypes();
+        foreach (var transactionTypeAmount in Transaction.TransactionTypeAmounts)
+            transactionTypeAmount.TransactionType = null;
+    }
+
+    private async Task OnAmountChanged(TransactionTypeAmountForm transactionTypeAmount, decimal? value)
+    {
+        transactionTypeAmount.Amount = value;
+        await CalculateMembershipExpirationDate();
+    }
+
+
+    private async Task CalculateMembershipExpirationDate()
+    {
+        if (!Transaction.Counterparty.MemberId.HasValue)
+        {
+            return;
+        }
+        var memberId = Transaction.Counterparty.MemberId.Value;
+        var member = await Mediator.Send(new GetMemberByIdQuery(memberId));
+        SelectedMember = member;
+        var transactionTypeForMembershipFee = Transaction.TransactionTypeAmounts
+            .SingleOrDefault(x => x.TransactionType == TransactionType.DebitMemberFee);
+
+        if (transactionTypeForMembershipFee != null &&
+            transactionTypeForMembershipFee.Amount is not null or 0 &&
+            SelectedMember.MembershipExpiryDate.HasValue && SelectedMember.MembershipFee != 0)
+        {
+            AmountOfMonths = (int)Math.Floor((double)transactionTypeForMembershipFee.Amount / SelectedMember.MembershipFee);
+            _newExpirationDate = SelectedMember.MembershipExpiryDate.Value.AddMonths(AmountOfMonths).Date;
+            Transaction.NewMembershipExpirationDate = _newExpirationDate;
+        }
+    }
+
+    private void SetMinReceivedDate(Guid? financialYearId)
+    {
+        Transaction.FinancialYearId = financialYearId;
+        MinReceivedDateTime = financialYearId is null
+            ? null
+            : _financialYears.Single(f => f.Id == financialYearId).StartDateTimeOffset.DateTime;
+    }
+
+    private async Task TrySetFinancialYearId()
+    {
+        if (Transaction.Id == default)
+            return;
+
+        var financialYear = await Mediator.Send(new GetFinancialYearByTransactionId(Transaction.Id))
+            ?? throw new Exception($"Couldn't get financial year id for transaction with id {Transaction.Id}");
+
+        Transaction.FinancialYearId = financialYear.Id;
+    }
+
+    private async Task SetFinancialYears()
+    {
+        _financialYears = await Mediator.Send(new GetFinancialYearsQuery());
+        if (Transaction.FinancialYearId is not null)
+            SetMinReceivedDate(Transaction.FinancialYearId);
+        else
+            SetMinReceivedDate(_financialYears.OrderByDescending(f => f.StartDateTimeOffset).First().Id);
+    }
+}


### PR DESCRIPTION
This forces a selection from the user for which financial year should be used.
Once a financial year has been selected, the transaction received date datepicker's minimal date is set to the start date of the financial year, making it impossible to add transactions in nonexisting financial years.
Closed financial years can not be selected, making it impossible to add new or change existing transactions to closed financial years.

Fixes #219 