### PR TITLE
fix: Register DbContext as transient instead of using DbContextFactory

### DIFF
--- a/Persistence/Extensions/DbContextExtensions.cs
+++ b/Persistence/Extensions/DbContextExtensions.cs
@@ -15,10 +15,12 @@ public static class DbContextExtensions
             throw new ArgumentException("The value cannot be empty or whitespace.", nameof(connectionString));
         }
 
-        serviceCollection.AddDbContextFactory<HaSpManContext>(options =>
-                    options.UseSqlServer(connectionString, b => b
+        serviceCollection.AddDbContext<HaSpManContext>(
+            options => options.UseSqlServer(connectionString, b => b
                         .MigrationsAssembly("Persistence")
-                        .MigrationsHistoryTable("__EFMigrationsHistory", "HaSpMan")));
+                        .MigrationsHistoryTable("__EFMigrationsHistory", "HaSpMan")),
+            ServiceLifetime.Transient);
+
         return serviceCollection;
     }
 

--- a/Persistence/Repositories/BankAccountRepository.cs
+++ b/Persistence/Repositories/BankAccountRepository.cs
@@ -9,9 +9,9 @@ public class BankAccountRepository : IBankAccountRepository
 {
     private readonly HaSpManContext _context;
 
-    public BankAccountRepository(IDbContextFactory<HaSpManContext> contextFactory)
+    public BankAccountRepository(HaSpManContext context)
     {
-        _context = contextFactory.CreateDbContext();
+        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
     public void Add(BankAccount account)

--- a/Persistence/Repositories/FinancialYearRepository.cs
+++ b/Persistence/Repositories/FinancialYearRepository.cs
@@ -10,10 +10,10 @@ public class FinancialYearRepository : IFinancialYearRepository
 
     private readonly HaSpManContext _context;
 
-    public FinancialYearRepository(IDbContextFactory<HaSpManContext> contextFactory)
+    public FinancialYearRepository(HaSpManContext context)
     {
 
-        _context = contextFactory.CreateDbContext();
+        _context = context;
     }
 
     public Task<FinancialYear?> GetByIdAsync(Guid id, CancellationToken cancellationToken)

--- a/Persistence/Repositories/MemberRepository.cs
+++ b/Persistence/Repositories/MemberRepository.cs
@@ -9,10 +9,10 @@ public class MemberRepository : IMemberRepository
 {
     private readonly HaSpManContext _context;
 
-    public MemberRepository(IDbContextFactory<HaSpManContext> contextFactory)
+    public MemberRepository(HaSpManContext context)
     {
 
-        _context = contextFactory.CreateDbContext();
+        _context = context;
     }
     public void Add(Member member)
     {

--- a/Queries/BankAccounts/GetBankAccountById.cs
+++ b/Queries/BankAccounts/GetBankAccountById.cs
@@ -1,3 +1,5 @@
+using AutoMapper.QueryableExtensions;
+
 using Microsoft.EntityFrameworkCore;
 
 using Persistence;
@@ -9,19 +11,17 @@ public record GetBankAccountByIdQuery(Guid Id) : IRequest<BankAccountDetail>;
 public class GetBankAccountByIdHandler : IRequestHandler<GetBankAccountByIdQuery, BankAccountDetail>
 {
     private readonly IMapper _mapper;
-    private readonly IDbContextFactory<HaSpManContext> _contextFactory;
+    private readonly HaSpManContext _context;
 
-    public GetBankAccountByIdHandler(IMapper mapper, IDbContextFactory<HaSpManContext> contextFactory)
+    public GetBankAccountByIdHandler(IMapper mapper, HaSpManContext context)
     {
-        _mapper = mapper;
-        _contextFactory = contextFactory;
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public async Task<BankAccountDetail> Handle(GetBankAccountByIdQuery request, CancellationToken cancellationToken)
-    {
-        var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-        var bankAccount = await context.BankAccounts.SingleAsync(b => b.Id == request.Id, cancellationToken: cancellationToken);
-
-        return _mapper.Map<BankAccountDetail>(bankAccount);
-    }
+    public Task<BankAccountDetail> Handle(GetBankAccountByIdQuery request, CancellationToken cancellationToken)
+        => _context.BankAccounts
+            .Where(b => b.Id == request.Id)
+            .ProjectTo<BankAccountDetail>(_mapper.ConfigurationProvider)
+            .SingleAsync(cancellationToken);
 }

--- a/Queries/BankAccounts/SearchBankAccounts.cs
+++ b/Queries/BankAccounts/SearchBankAccounts.cs
@@ -28,19 +28,18 @@ public enum BankAccountDetailOrderOption
 
 public class SearchBankAccountsHandler : IRequestHandler<SearchBankAccountsQuery, Paginated<BankAccountDetailWithTotal>>
 {
-    private readonly IDbContextFactory<HaSpManContext> _contextFactory;
+    private readonly HaSpManContext _context;
     private readonly IMapper _mapper;
 
-    public SearchBankAccountsHandler(IDbContextFactory<HaSpManContext> contextFactory, IMapper mapper)
+    public SearchBankAccountsHandler(HaSpManContext context, IMapper mapper)
     {
-        _contextFactory = contextFactory;
-        _mapper = mapper;
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public async Task<Paginated<BankAccountDetailWithTotal>> Handle(SearchBankAccountsQuery request, CancellationToken cancellationToken)
     {
-        var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-        var bankAccountsQueryable = context.BankAccounts
+        var bankAccountsQueryable = _context.BankAccounts
             .AsNoTracking()
             .Where(GetFilterCriteria(request.SearchString));
 

--- a/Queries/FinancialYears/GetFinancialYearsQuery.cs
+++ b/Queries/FinancialYears/GetFinancialYearsQuery.cs
@@ -8,22 +8,19 @@ public record GetFinancialYearsQuery() : IRequest<IReadOnlyList<FinancialYear>>;
 
 public class GetFinancialYearsHandler : IRequestHandler<GetFinancialYearsQuery, IReadOnlyList<FinancialYear>>
 {
-    private readonly IDbContextFactory<HaSpManContext> _contextFactory;
+    private readonly HaSpManContext _context;
 
-    public GetFinancialYearsHandler(IDbContextFactory<HaSpManContext> contextFactory)
+    public GetFinancialYearsHandler(HaSpManContext context)
     {
-        _contextFactory = contextFactory;
+        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
-    
+
     public async Task<IReadOnlyList<FinancialYear>> Handle(GetFinancialYearsQuery request,
         CancellationToken cancellationToken)
     {
-        var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-        var financialYears = await context.FinancialYears.ToListAsync(cancellationToken);
-
-        return financialYears
+        return await _context.FinancialYears
             .OrderByDescending(x => x.StartDate)
             .Select(x => new FinancialYear(x.Id, x.StartDate, x.EndDate, x.IsClosed, x.Name))
-            .ToList();
+            .ToListAsync(cancellationToken);
     }
 }

--- a/Queries/Members/Handlers/AutocompleteMember/AutocompleteCounterpartyHandler.cs
+++ b/Queries/Members/Handlers/AutocompleteMember/AutocompleteCounterpartyHandler.cs
@@ -6,19 +6,17 @@ namespace Queries.Members.Handlers.AutocompleteMember;
 
 public class AutocompleteCounterpartyHandler : IRequestHandler<AutocompleteCounterpartyQuery, AutocompleteCounterpartyResponse>
 {
-    private readonly IDbContextFactory<HaSpManContext> _contextFactory;
+    private readonly HaSpManContext _context;
 
-    public AutocompleteCounterpartyHandler(IDbContextFactory<HaSpManContext> contextFactory)
+    public AutocompleteCounterpartyHandler(HaSpManContext context)
     {
-        _contextFactory = contextFactory;
+        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
     public async Task<AutocompleteCounterpartyResponse> Handle(AutocompleteCounterpartyQuery request, CancellationToken cancellationToken)
     {
-        var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-
         if (request.IsMemberSearch)
         {
-            var members = await context.Members
+            var members = await _context.Members
                 .Where(x =>
                     x.FirstName.ToLower().Contains(request.SearchString.ToLower()) ||
                     x.LastName.ToLower().Contains(request.SearchString.ToLower()))
@@ -27,7 +25,7 @@ public class AutocompleteCounterpartyHandler : IRequestHandler<AutocompleteCount
             return new AutocompleteCounterpartyResponse(members);
         }
 
-        var counterParties = await context.FinancialYears
+        var counterParties = await _context.FinancialYears
             .SelectMany(x => x.Transactions)
             .AsNoTracking()
             .Where(x =>

--- a/Queries/Members/Handlers/GetBankAccountInfos/GetBankAccountInfosHandler.cs
+++ b/Queries/Members/Handlers/GetBankAccountInfos/GetBankAccountInfosHandler.cs
@@ -6,20 +6,16 @@ namespace Queries.Members.Handlers.GetBankAccountInfos;
 
 public class GetBankAccountInfosHandler : IRequestHandler<GetBankAccountInfos, IReadOnlyList<BankAccountInfo>>
 {
-    private readonly IDbContextFactory<HaSpManContext> _contextFactory;
+    private readonly HaSpManContext _context;
 
-    public GetBankAccountInfosHandler(IDbContextFactory<HaSpManContext> contextFactory)
+    public GetBankAccountInfosHandler(HaSpManContext context)
     {
-        _contextFactory = contextFactory;
+        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
     public async Task<IReadOnlyList<BankAccountInfo>> Handle(GetBankAccountInfos request, CancellationToken cancellationToken)
-    {
-        await using var context = _contextFactory.CreateDbContext();
-        return await context.BankAccounts
+        => await _context.BankAccounts
             .AsNoTracking()
             .Select(x => new BankAccountInfo(x.Id, x.Name))
             .ToListAsync(cancellationToken);
-
-    }
 }

--- a/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
+++ b/Queries/Members/Handlers/SearchMembers/SearchMembersHandler.cs
@@ -13,18 +13,16 @@ namespace Queries.Members.Handlers.SearchMembers;
 
 public class SearchMembersHandler : IRequestHandler<SearchMembersQuery, Paginated<MemberSummary>>
 {
-    private readonly IDbContextFactory<HaSpManContext> _contextFactory;
+    private readonly HaSpManContext _context;
 
-    public SearchMembersHandler(IDbContextFactory<HaSpManContext> contextFactory)
+    public SearchMembersHandler(HaSpManContext context)
     {
-        _contextFactory = contextFactory;
+        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
     public async Task<Paginated<MemberSummary>> Handle(SearchMembersQuery request, CancellationToken cancellationToken)
     {
-        var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-        var memberQueryable = context.Members
-
+        var memberQueryable = _context.Members
             .AsNoTracking()
             .Where(GetTextFilterCriteria(request.SearchString));
 

--- a/Queries/Members/MemberExistsByEmailQuery.cs
+++ b/Queries/Members/MemberExistsByEmailQuery.cs
@@ -12,18 +12,16 @@ public record MemberExistsByEmailQuery(string EmailAddress, Guid? ExcludeId = nu
 
 public class MemberExistsByEmail : IRequestHandler<MemberExistsByEmailQuery, bool>
 {
-    private readonly HaSpManContext _dbContext;
+    private readonly HaSpManContext _context;
 
-    public MemberExistsByEmail(IDbContextFactory<HaSpManContext> dbContextFactory)
+    public MemberExistsByEmail(HaSpManContext context)
     {
-        _dbContext = dbContextFactory.CreateDbContext();
+        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
     public Task<bool> Handle(MemberExistsByEmailQuery request, CancellationToken cancellationToken)
     {
-        return _dbContext.Members
-            .AsNoTracking()
-            .AnyAsync(BuildQueryPredicate(request), cancellationToken);
+        return _context.Members.AnyAsync(BuildQueryPredicate(request), cancellationToken);
     }
 
     private static Expression<Func<Member, bool>> BuildQueryPredicate(MemberExistsByEmailQuery request) => request.ExcludeId is null

--- a/Queries/Members/MemberExistsByNameAndAddressQuery.cs
+++ b/Queries/Members/MemberExistsByNameAndAddressQuery.cs
@@ -22,9 +22,9 @@ public class MemberExistsByNameAndAddress : IRequestHandler<MemberExistsByNameAn
 {
     private readonly HaSpManContext _dbContext;
 
-    public MemberExistsByNameAndAddress(IDbContextFactory<HaSpManContext> dbContextFactory)
+    public MemberExistsByNameAndAddress(HaSpManContext dbContext)
     {
-        _dbContext = dbContextFactory.CreateDbContext();
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
     }
 
     public Task<bool> Handle(MemberExistsByNameAndAddressQuery request, CancellationToken cancellationToken)

--- a/Queries/Transactions/GetAttachment/GetAttachmentCommand.cs
+++ b/Queries/Transactions/GetAttachment/GetAttachmentCommand.cs
@@ -12,20 +12,19 @@ public record GetAttachmentQuery(Guid TransactionId, string FileName) : IRequest
 
 public class GetAttachmentHandler : IRequestHandler<GetAttachmentQuery, Attachment>
 {
-    private readonly IDbContextFactory<HaSpManContext> _dbContextFactory;
+    private readonly HaSpManContext _dbContext;
     private readonly IAttachmentStorage _attachmentStorage;
 
-    public GetAttachmentHandler(IDbContextFactory<HaSpManContext> dbContextFactory, IAttachmentStorage attachmentStorage)
+    public GetAttachmentHandler(HaSpManContext dbContext, IAttachmentStorage attachmentStorage)
     {
-        _dbContextFactory = dbContextFactory;
-        _attachmentStorage = attachmentStorage;
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _attachmentStorage = attachmentStorage ?? throw new ArgumentNullException(nameof(attachmentStorage));
     }
     public async Task<Attachment> Handle(GetAttachmentQuery request, CancellationToken cancellationToken)
     {
-        var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
         var transactionId = request.TransactionId;
         var transaction =
-            await context.FinancialYears
+            await _dbContext.FinancialYears
                 .SelectMany(x => x.Transactions)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(x => x.Id == transactionId, cancellationToken)

--- a/Queries/Transactions/Handlers/GetTransactionsHandler.cs
+++ b/Queries/Transactions/Handlers/GetTransactionsHandler.cs
@@ -15,20 +15,18 @@ namespace Queries.Transactions.Handlers;
 
 public class GetTransactionsHandler : IRequestHandler<GetTransactionQuery, Paginated<TransactionSummary>>
 {
-    private readonly IDbContextFactory<HaSpManContext> _contextFactory;
+    private readonly HaSpManContext _dbContext;
     private readonly IMapper _mapper;
 
-    public GetTransactionsHandler(IDbContextFactory<HaSpManContext> contextFactory, IMapper mapper)
+    public GetTransactionsHandler(HaSpManContext dbContext, IMapper mapper)
     {
-        _contextFactory = contextFactory;
-        _mapper = mapper;
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public async Task<Paginated<TransactionSummary>> Handle(GetTransactionQuery request, CancellationToken cancellationToken)
     {
-        var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-
-        var baseQuery = context.FinancialYears
+        var baseQuery = _dbContext.FinancialYears
             .AsNoTracking()
             .SelectMany(y => y.Transactions)
             .Where(GetFilterCriteria(request.SearchString));

--- a/Web/Pages/Transactions/TransactionForm.razor.cs
+++ b/Web/Pages/Transactions/TransactionForm.razor.cs
@@ -243,6 +243,7 @@ public partial class TransactionForm : ComponentBase
             ?? throw new Exception($"Couldn't get financial year id for transaction with id {Transaction.Id}");
 
         Transaction.FinancialYearId = financialYear.Id;
+        await Task.Delay(1000);
     }
 
     private async Task SetFinancialYears()


### PR DESCRIPTION
This achieves the same: A specific DbContext instance per class, as using DbContextFactory and creating a local instance everywhere.

In the latest changes I made I forgot to use DbContextFactory which caused concurrent DbContext operation exceptions when editing transactions. 
This implements a more developer-friendly solution in that we can just inject `HaSpManContext` as we would normally without having to worry about its lifetime.

Fixes #237 